### PR TITLE
Added badges to Chinese and Japanese doc and updated translation badge hash values in README.md

### DIFF
--- a/README_JA.md
+++ b/README_JA.md
@@ -13,8 +13,8 @@
     <a href='./README.md'>English</a> | 日本語 | <a href='./README_zh-CN.md'>简体中文</a> | <a href='./README_zh-TW.md'>繁體中文</a>
 </p>
 
-[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3DREADME.md%26commit_hash%3D46ffc45c6890d939b97fb5aa18338d554d3a8696)
-](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=README.md&commit_hash=46ffc45c6890d939b97fb5aa18338d554d3a8696)
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3DREADME.md%26commit_hash%3D585ebe9d59fb2190c8c3aeca49d53385a5f7e256)
+](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=README.md&commit_hash=585ebe9d59fb2190c8c3aeca49d53385a5f7e256)
 
 ## Ergはこんな人におすすめです&#58;
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -13,8 +13,8 @@
     <a href='./README.md'>English</a> | <a href='./README_JA.md'>日本語</a> | 简体中文 | <a href='./README_zh-TW.md'>繁體中文</a>
 </p>
 
-[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3DREADME.md%26commit_hash%3D46ffc45c6890d939b97fb5aa18338d554d3a8696)
-](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=README.md&commit_hash=46ffc45c6890d939b97fb5aa18338d554d3a8696)
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3DREADME.md%26commit_hash%3D585ebe9d59fb2190c8c3aeca49d53385a5f7e256)
+](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=README.md&commit_hash=585ebe9d59fb2190c8c3aeca49d53385a5f7e256)
 
 ## Erg可以推荐给以下人员&colon;
 

--- a/README_zh-TW.md
+++ b/README_zh-TW.md
@@ -13,8 +13,8 @@
     <a href='./README.md'>English</a> | <a href='./README_JA.md'>日本語</a> | <a href='./README_zh-CN.md'>简体中文</a> | 繁體中文
 </p>
 
-[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3DREADME.md%26commit_hash%3D46ffc45c6890d939b97fb5aa18338d554d3a8696)
-](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=README.md&commit_hash=46ffc45c6890d939b97fb5aa18338d554d3a8696)
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3DREADME.md%26commit_hash%3D585ebe9d59fb2190c8c3aeca49d53385a5f7e256)
+](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=README.md&commit_hash=585ebe9d59fb2190c8c3aeca49d53385a5f7e256)
 
 ## Erg可以推薦給以下人員&colon;
 

--- a/doc/JA/API/consts.md
+++ b/doc/JA/API/consts.md
@@ -1,5 +1,7 @@
 # 組み込み定数
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/consts.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/consts.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 ## True
 
 ## False

--- a/doc/JA/API/funcs.md
+++ b/doc/JA/API/funcs.md
@@ -1,5 +1,7 @@
 # 関数
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/funcs.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/funcs.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 ## 基本関数
 
 ### if|T; U|(cond: Bool, then: T, else: U) -> T or U

--- a/doc/JA/API/index.md
+++ b/doc/JA/API/index.md
@@ -1,0 +1,2 @@
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/index.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/index.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+

--- a/doc/JA/API/modules/external/alstruct.md
+++ b/doc/JA/API/modules/external/alstruct.md
@@ -1,5 +1,7 @@
 # alstruct
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/modules/external/alstruct.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/modules/external/alstruct.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 代数的構造を表すトレイトや、それにかかるパッチを提供するモジュール。
 
 * member

--- a/doc/JA/API/modules/repl.md
+++ b/doc/JA/API/modules/repl.md
@@ -1,5 +1,7 @@
 # module `repl`
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/modules/repl.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/modules/repl.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 provides REPL(Read-Eval-Print-Loop)-related APIs.
 
 ## functions

--- a/doc/JA/API/modules/status.md
+++ b/doc/JA/API/modules/status.md
@@ -1,5 +1,7 @@
 # module `status`
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/modules/status.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/modules/status.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 状態を表す型が定義されています。状況に応じて選択肢を外したりして使用してください。
 
 * ExecResult = {"success", "warning", "failure", "fatal", "unknown"}

--- a/doc/JA/API/modules/unit.md
+++ b/doc/JA/API/modules/unit.md
@@ -1,5 +1,7 @@
 # module `unit`
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/modules/unit.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/modules/unit.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 `unit`モジュールは数値計算でよく使われる単位を型として定義したモジュールです。
 Ergの数値型は`Nat`, `Int`, `Ratio`などがあります。しかしこれらの型は「何を意味する数値なのか」という情報を持っておらず、メートルとヤード同士の足し算などといったナンセンスな計算を行えてしまいます。
 `unit`モジュールを使うことにより、単位の違う数値を関数に渡すといったミスを防げます。

--- a/doc/JA/API/modules/unsound.md
+++ b/doc/JA/API/modules/unsound.md
@@ -1,5 +1,7 @@
 # module `unsound`
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/modules/unsound.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/modules/unsound.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 Provides APIs perform unsound and unsafe operations that cannot be guaranteed safe in Erg's type system.
 
 ## `unsafe!`

--- a/doc/JA/API/operators.md
+++ b/doc/JA/API/operators.md
@@ -1,5 +1,7 @@
 # 演算子
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/operators.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/operators.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 ## 中置演算子
 
 ### `_+_`|R; O; A <: Add(R, O)|(x: A, y: R) -> O

--- a/doc/JA/API/procs.md
+++ b/doc/JA/API/procs.md
@@ -1,5 +1,7 @@
 # プロシージャ
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/procs.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/procs.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 ## print!
 
 ```python

--- a/doc/JA/API/special.md
+++ b/doc/JA/API/special.md
@@ -1,5 +1,7 @@
 
 # 特殊形式(Special form)
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/special.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/special.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 
 特殊形式は、Ergの型システムでは表現ができない演算子、サブルーチン(のようなもの)である。``で囲っているが、実際は捕捉できない。
 また、`Pattern`や`Body`, `Conv`といった型が便宜上登場するが、そのような型が存在するわけではない。その意味もコンテクストによって異なる。

--- a/doc/JA/API/types.md
+++ b/doc/JA/API/types.md
@@ -1,5 +1,7 @@
 # Erg組み込み型一覧
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 型自体の属性は`.__dict__`の中には格納されていないので、インスタンスからは参照できない
 
 ## 汎用型 (Fundamental types)

--- a/doc/JA/API/types/classes/Array!(T).md
+++ b/doc/JA/API/types/classes/Array!(T).md
@@ -1,4 +1,6 @@
 # Array! T
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Array!(T).md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Array!(T).md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 可変長配列を表す型。コンパイル時に長さがわからない場合に使う。`[T]!`という糖衣構文がある。
 `Array! T = ArrayWithMutLength! T, !_`で定義される。

--- a/doc/JA/API/types/classes/Array(T).md
+++ b/doc/JA/API/types/classes/Array(T).md
@@ -1,3 +1,5 @@
 # Array T: Type
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Array(T).md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Array(T).md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 `Array T = ArrayWithLen T, _`で定義される。`[T]`という糖衣構文がある。

--- a/doc/JA/API/types/classes/ArrayWithLen(T,N).md
+++ b/doc/JA/API/types/classes/ArrayWithLen(T,N).md
@@ -1,5 +1,7 @@
 # ArrayWithLen T: Type, N: Nat
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/ArrayWithLen(T,N).md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/ArrayWithLen(T,N).md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 `[T; N]`は糖衣構文。長さを省いた[`Array`型](./Array.md)もある。
 
 ## methods

--- a/doc/JA/API/types/classes/ArrayWithMutLength!(T,N).md
+++ b/doc/JA/API/types/classes/ArrayWithMutLength!(T,N).md
@@ -1,5 +1,7 @@
 # ArrayWithMutLength! T: Type, N: Nat&excl;
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/ArrayWithMutLength!(T,N).md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/ArrayWithMutLength!(T,N).md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 コンパイル時に長さのわかる可変長配列。`ArrayWithMutLength(T, !N) == [T; !N]`という糖衣構文もある。
 
 ## methods

--- a/doc/JA/API/types/classes/Class.md
+++ b/doc/JA/API/types/classes/Class.md
@@ -1,0 +1,2 @@
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Class.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Class.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+

--- a/doc/JA/API/types/classes/Complex.md
+++ b/doc/JA/API/types/classes/Complex.md
@@ -1,5 +1,7 @@
 # Complex
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Complex.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Complex.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 複素数を表す型です。Ergで数字を表す型、例えばFloatやInt、Natなどは、大抵この型を上位に持ちます。
 
 ## supers

--- a/doc/JA/API/types/classes/Dict!.md
+++ b/doc/JA/API/types/classes/Dict!.md
@@ -1,5 +1,7 @@
 # Dict! K, V
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Dict!.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Dict!.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 辞書(ハッシュマップ)を表す型。`{K: V}`という構文糖が存在する。
 
 ## methods

--- a/doc/JA/API/types/classes/Either.md
+++ b/doc/JA/API/types/classes/Either.md
@@ -1,5 +1,7 @@
 # Either L, R = L or R
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Either.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Either.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 「LかRかどちらか」を表す型。Or型の2つ限定形と考えて良い。
 
 ## methods

--- a/doc/JA/API/types/classes/Float.md
+++ b/doc/JA/API/types/classes/Float.md
@@ -1,5 +1,7 @@
 # Float size
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Float.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Float.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 実数(小数を含む数)を表す型です。IEEE 754に準拠した浮動小数点数を表し、他の言語では一般的にfloatに相当する型です。
 Float sizeのsizeは、8(1byte)~128(16byte)となります。単にFloatとした場合`Float 64`を表します。
 Ergでの0.1は実はFloat型ではなく、Ratio型に属します。Float型のリテラルは存在せず、`(Ratioオブジェクト)f64`(e.g. (1/2)f64, 15f64)で生成します。f64は実数の1に対応します。

--- a/doc/JA/API/types/classes/Function(N).md
+++ b/doc/JA/API/types/classes/Function(N).md
@@ -1,5 +1,7 @@
 # Function N: Nat
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Function(N).md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Function(N).md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 ## methods of Function 1
 
 * then(self, g: Self) -> Self

--- a/doc/JA/API/types/classes/Inf.md
+++ b/doc/JA/API/types/classes/Inf.md
@@ -1,5 +1,7 @@
 # Inf
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Inf.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Inf.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 Infはinfただひとつをインスタンスとするクラスである。
 infの主な使いみちは、区間型での使用である。
 例えば、2以上の整数型は`2..<inf`となり、0以下の実数は`-inf<..0.0`となる。

--- a/doc/JA/API/types/classes/Int.md
+++ b/doc/JA/API/types/classes/Int.md
@@ -1,5 +1,7 @@
 # Int
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Int.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Int.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 整数(Integer)を表すクラスです。インスタンスは0, 1, -1, 300000などがあります。
 多くの言語では自然数を表す場合でもInt(に相当する型)を使用しますが、Ergではuse smaller typesの原則により、
 Nat, NZInt, Interval型などを使用することが推奨されます。

--- a/doc/JA/API/types/classes/IntRange.md
+++ b/doc/JA/API/types/classes/IntRange.md
@@ -1,5 +1,7 @@
 # IntRange L, R
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/IntRange.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/IntRange.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 `L..R`のクラス。
 
 ```python

--- a/doc/JA/API/types/classes/Interval.md
+++ b/doc/JA/API/types/classes/Interval.md
@@ -1,5 +1,7 @@
 # Interval begin, end := WellOrder
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Interval.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Interval.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 整列集合型(WellOrder)の部分型を表す型です。Interval型にはPreOpen(x<..y)などの派生型が存在します。
 
 ```python

--- a/doc/JA/API/types/classes/Iterator.md
+++ b/doc/JA/API/types/classes/Iterator.md
@@ -1,0 +1,2 @@
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Iterator.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Iterator.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+

--- a/doc/JA/API/types/classes/Kind(N).md
+++ b/doc/JA/API/types/classes/Kind(N).md
@@ -1,5 +1,7 @@
 # Kind N: Nat
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Kind(N).md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Kind(N).md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 ```python
 Kind N: Nat = (Type; N) -> Type
 ```

--- a/doc/JA/API/types/classes/Matrix.md
+++ b/doc/JA/API/types/classes/Matrix.md
@@ -1,5 +1,7 @@
 # Matrix T: Num, Shape: [M, N]
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Matrix.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Matrix.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 行列を表す型です。Tensor [M, N]を継承しています。
 
 ## def

--- a/doc/JA/API/types/classes/Module.md
+++ b/doc/JA/API/types/classes/Module.md
@@ -1,3 +1,5 @@
 # Module
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Module.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Module.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 ## methods

--- a/doc/JA/API/types/classes/Nat.md
+++ b/doc/JA/API/types/classes/Nat.md
@@ -1,5 +1,7 @@
 # Nat
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Nat.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Nat.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 自然数を表す型。配列のインデックスや範囲型などで使われる。
 
 ## def

--- a/doc/JA/API/types/classes/Neg.md
+++ b/doc/JA/API/types/classes/Neg.md
@@ -1,5 +1,7 @@
 # Neg
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Neg.md%26commit_hash%3D290c43b09f7c3036112a164bed5fd07a1f6a5cda)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Neg.md&commit_hash=290c43b09f7c3036112a164bed5fd07a1f6a5cda)
+
 負の整数を表す型です。Pos and Neg and {0} == Intとなります。
 ゼロ除算が起きない、Neg * Neg == Posとなるなど、いくつか特筆すべき性質も持っています。
 

--- a/doc/JA/API/types/classes/Never.md
+++ b/doc/JA/API/types/classes/Never.md
@@ -1,5 +1,7 @@
 # Never
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Never.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Never.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 全ての型の下位型である。全てのメソッドを持っており、当然`.new`も持っているため`Class`である。しかしインスタンスは持たず、生成されそうになった瞬間にErgは停止する。
 `Panic`という同じくインスタンスを持たない型が存在するが、正常に終了する際や意図的な無限ループの際は`Never`、異常終了する際には`Panic`を使う。
 

--- a/doc/JA/API/types/classes/NonZero.md
+++ b/doc/JA/API/types/classes/NonZero.md
@@ -1,5 +1,7 @@
 # NonZero N
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/NonZero.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/NonZero.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 ゼロではない数を表すクラスです。ゼロ除算の安全性が保証されます。
 
 ```mermaid

--- a/doc/JA/API/types/classes/Object.md
+++ b/doc/JA/API/types/classes/Object.md
@@ -1,5 +1,7 @@
 # Object
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Object.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Object.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 全ての型の上位型である。
 
 ## methods

--- a/doc/JA/API/types/classes/Operator.md
+++ b/doc/JA/API/types/classes/Operator.md
@@ -1,5 +1,7 @@
 # Operator [...T], O
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Operator.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Operator.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 演算子の型です。
 
 ## def

--- a/doc/JA/API/types/classes/Option.md
+++ b/doc/JA/API/types/classes/Option.md
@@ -1,5 +1,7 @@
 # Option T = T or NoneType
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Option.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Option.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 「失敗するかもしれない」を表す型。
 
 ## methods

--- a/doc/JA/API/types/classes/Pos.md
+++ b/doc/JA/API/types/classes/Pos.md
@@ -1,5 +1,7 @@
 # Pos
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Pos.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Pos.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 Posは正数(1以上の整数)を表す型です。
 0が入らないので、ゼロ除算の可能性を排除できるなどのメリットがあります。
 

--- a/doc/JA/API/types/classes/Ratio.md
+++ b/doc/JA/API/types/classes/Ratio.md
@@ -1,5 +1,7 @@
 # Ratio
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Ratio.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Ratio.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 有理数を表す型です。主に、分数を使いたいときに使います。
 実はErgでの/演算子はRatioを返します。1/3などは0.33333...とは評価されず1/3のまま処理されます。また、0.1は1/10と等価です。なので、`0.1 + 0.2 == 0.3`となります。当たり前のように聞こえますが、PythonではなんとFalseになります。
 とはいえ、Ratio型はFloat型に比べて若干効率が下がる傾向があります。そこまで正確な数値は要らず、かつ実行速度が重要となるポイントではFloat型を使用するといいでしょう。とはいえ、Rob Pikeが言うように早すぎる最適化は諸悪の根源です。Ratio型を捨ててFloat型を使用するのは実際にパフォーマンステストを行ってからにしましょう。素人ほど無条件に軽量な型を好みます。

--- a/doc/JA/API/types/classes/Record.md
+++ b/doc/JA/API/types/classes/Record.md
@@ -1,5 +1,7 @@
 # Record
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Record.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Record.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 レコードの属するクラス。例えば`{i = 1}`は`Structural {i = Int}`型などの要素であり、`{i = Int}`クラスのインスタンスである。
 他のクラスのインスタンスはレコード型の要素であってもレコードクラスのインスタンスではないことに注意。
 

--- a/doc/JA/API/types/classes/Result.md
+++ b/doc/JA/API/types/classes/Result.md
@@ -1,5 +1,7 @@
 # Result T, E
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Result.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Result.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 ```python
 Result T, E <: Error = Either T, E
 ```

--- a/doc/JA/API/types/classes/Str!.md
+++ b/doc/JA/API/types/classes/Str!.md
@@ -1,3 +1,5 @@
 # StrWithLen! N: Nat! = Inherit StrWithLen N
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Str!.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Str!.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 可変長文字列を表す型。

--- a/doc/JA/API/types/classes/Str.md
+++ b/doc/JA/API/types/classes/Str.md
@@ -1,5 +1,7 @@
 # Str
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Str.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Str.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 (不変長)文字列を表す型。単なる`Str`型は`StrWithLen N`型から文字数の情報を落とした型である(`Str = StrWithLen _`)。
 
 ## methods

--- a/doc/JA/API/types/classes/StrWithLen.md
+++ b/doc/JA/API/types/classes/StrWithLen.md
@@ -1,0 +1,2 @@
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/StrWithLen.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/StrWithLen.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+

--- a/doc/JA/API/types/classes/Subroutine.md
+++ b/doc/JA/API/types/classes/Subroutine.md
@@ -1,5 +1,7 @@
 # Subroutine
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Subroutine.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Subroutine.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 FuncやProcの基底型です。
 
 ## methods

--- a/doc/JA/API/types/classes/Tensor.md
+++ b/doc/JA/API/types/classes/Tensor.md
@@ -1,5 +1,7 @@
 # Tensor Shape: [Nat; N]
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Tensor.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Tensor.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
   多次元配列を効率的に操作するためのクラス。多次元配列に対する積などの演算も定義する。
   Matrix, Vectorなどはこの型を継承している。
 

--- a/doc/JA/API/types/classes/TransCell(T).md
+++ b/doc/JA/API/types/classes/TransCell(T).md
@@ -1,5 +1,7 @@
 # TransCell! T: Type!
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/TransCell(T).md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/TransCell(T).md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 中身を型ごと変えられるセルです。T型のサブタイプとなるので、T型としても振る舞います。
 初期化時点ではT型で、ある時点以降はずっとU型、といった場合に便利です。
 

--- a/doc/JA/API/types/classes/Tuple.md
+++ b/doc/JA/API/types/classes/Tuple.md
@@ -1,5 +1,7 @@
 # Tuple T: ...Type
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Tuple.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Tuple.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 複数の型のオブジェクトを保持するコレクション。
 
 ## methods

--- a/doc/JA/API/types/classes/Type.md
+++ b/doc/JA/API/types/classes/Type.md
@@ -1,0 +1,2 @@
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Type.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Type.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+

--- a/doc/JA/API/types/classes/Vector.md
+++ b/doc/JA/API/types/classes/Vector.md
@@ -1,3 +1,5 @@
 # Vector T: Num, N: Nat
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Vector.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Vector.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 ベクトルを表す型です。RustやC++などの同名の型と違い、この型が扱うのは数値専用です。

--- a/doc/JA/API/types/patches/BinOp.md
+++ b/doc/JA/API/types/patches/BinOp.md
@@ -1,5 +1,7 @@
 # BinOp L, R, O
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/patches/BinOp.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/patches/BinOp.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 二項演算子の型です。
 
 ## Patches

--- a/doc/JA/API/types/patches/UnaryOp.md
+++ b/doc/JA/API/types/patches/UnaryOp.md
@@ -1,5 +1,7 @@
 # UnaryOp T, O
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/patches/UnaryOp.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/patches/UnaryOp.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 単項演算子の型です。
 
 ## def

--- a/doc/JA/API/types/traits/Add(R,O).md
+++ b/doc/JA/API/types/traits/Add(R,O).md
@@ -1,5 +1,7 @@
 # Add R
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/traits/Add(R,O).md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/traits/Add(R,O).md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 ```python
 Add R = Trait {
     .AddO = Type

--- a/doc/JA/API/types/traits/Div(R,O).md
+++ b/doc/JA/API/types/traits/Div(R,O).md
@@ -1,5 +1,7 @@
 # Div R, O
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/traits/Div(R,O).md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/traits/Div(R,O).md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 ゼロ除算によるエラーがない場合は`SafeDiv`を使ってください。
 
 ```python

--- a/doc/JA/API/types/traits/Eq.md
+++ b/doc/JA/API/types/traits/Eq.md
@@ -1,0 +1,2 @@
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/traits/Eq.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/traits/Eq.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+

--- a/doc/JA/API/types/traits/Into.md
+++ b/doc/JA/API/types/traits/Into.md
@@ -1,5 +1,7 @@
 # Into T
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/traits/Into.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/traits/Into.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 T型に型変換可能であることを示す型です。
 SelfとTの間に継承関係などがなくても、互いに変換可能な関係であるときに定義します。
 継承と違い暗黙には変換が行われません。必ず`.into`メソッドを呼び出す必要があります。

--- a/doc/JA/API/types/traits/Iterable.md
+++ b/doc/JA/API/types/traits/Iterable.md
@@ -1,0 +1,2 @@
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/traits/Iterable.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/traits/Iterable.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+

--- a/doc/JA/API/types/traits/Num.md
+++ b/doc/JA/API/types/traits/Num.md
@@ -1,5 +1,7 @@
 # Num
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/traits/Num.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/traits/Num.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 ## definition
 
 ```python

--- a/doc/JA/API/types/traits/Ord.md
+++ b/doc/JA/API/types/traits/Ord.md
@@ -1,0 +1,2 @@
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/traits/Ord.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/traits/Ord.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+

--- a/doc/JA/API/types/traits/SafeDiv(R,O).md
+++ b/doc/JA/API/types/traits/SafeDiv(R,O).md
@@ -1,5 +1,7 @@
 # SafeDiv R, O
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/traits/SafeDiv(R,O).md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/traits/SafeDiv(R,O).md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 ```python
 SafeDiv R, O = Subsume Div, {
     @Override

--- a/doc/JA/API/types/traits/Sample.md
+++ b/doc/JA/API/types/traits/Sample.md
@@ -1,5 +1,7 @@
 # Sample
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/traits/Sample.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/traits/Sample.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 インスタンスを「適当に」選出する`sample`メソッドと`sample!`メソッドを持つトレイト。`sample`メソッドは常に同じインスタンスを返し、`sample!`メソッドは呼び出しごとに変わる適当なインスタンスを返す。
 
 これはテストなどで適当なインスタンスがほしい場合を想定したトレイトであり、必ずしも無作為ではないことに注意が必要である。無作為抽出が必要な場合は`random`モジュールを使用する。

--- a/doc/JA/API/types/traits/Seq.md
+++ b/doc/JA/API/types/traits/Seq.md
@@ -1,0 +1,2 @@
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/traits/Seq.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/traits/Seq.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+

--- a/doc/JA/API/types/traits/Show.md
+++ b/doc/JA/API/types/traits/Show.md
@@ -1,0 +1,2 @@
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/traits/Show.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/traits/Show.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+

--- a/doc/JA/API/types/traits/Unpack.md
+++ b/doc/JA/API/types/traits/Unpack.md
@@ -1,5 +1,7 @@
 # Unpack
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/traits/Unpack.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/traits/Unpack.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 マーカートレイト。実装すると、レコードのようにパターンマッチで要素を分解できる。
 
 ```python

--- a/doc/JA/compiler/TODO_hint.md
+++ b/doc/JA/compiler/TODO_hint.md
@@ -1,4 +1,6 @@
 # Hint (not implemented)
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/compiler/TODO_hint.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/compiler/TODO_hint.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 * `x is not defined` (x was deleted by `Del`) => `hint: deleted in line X`
 * patch method duplication: "hint: Specify patch (like `T.foo(1)`) or delete either `.foo` using `Del`"

--- a/doc/JA/compiler/TODO_recov_suggest.md
+++ b/doc/JA/compiler/TODO_recov_suggest.md
@@ -1,5 +1,7 @@
 # Error recovery suggestions (not implemented yet)
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/compiler/TODO_recov_suggest.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/compiler/TODO_recov_suggest.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 * `1 or 2`, `1 and 2` => `{1, 2}`?
 * `U = Inherit T` => Non-class type cannot be inherited, or `U = Class T`?
 * `Int and Str` => Multiple inheritance is not allowed, or `Int or Str`?

--- a/doc/JA/compiler/TODO_warn.md
+++ b/doc/JA/compiler/TODO_warn.md
@@ -1,5 +1,7 @@
 # warnings (not implemented yet)
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/compiler/TODO_warn.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/compiler/TODO_warn.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 * `t = {(record type)}` => `T = {(record type)}`? (only types defined as constants can be used for type specification)
 * `{I: Int | ...}!` => `{I: Int! | ...}`
 * `return x`(`x != ()`) in for/while block => `f::return` (outer block)?

--- a/doc/JA/compiler/abandoned.md
+++ b/doc/JA/compiler/abandoned.md
@@ -1,5 +1,7 @@
 # 放棄・却下された言語仕様
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/compiler/abandoned.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/compiler/abandoned.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 ## オーバーロード(アドホック多相)
 
 パラメトリック+サブタイピング多相で代替できること、Pythonの意味論との相性の悪さなどを理由に放棄された。詳しくは[overload](../syntax/type/overloading.md)の記事を参照。

--- a/doc/JA/compiler/architecture.md
+++ b/doc/JA/compiler/architecture.md
@@ -1,5 +1,7 @@
 # ergc のアーキテクチャ
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/compiler/architecture.md%26commit_hash%3Da711efa99b325ba1012f6897e7b0e2bdb947d8a1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/compiler/architecture.md&commit_hash=a711efa99b325ba1012f6897e7b0e2bdb947d8a1)
+
 ## 1. Erg スクリプト (.er) をスキャンし、`TokenStream` (parser/lex.rs) を生成する
 
 * parser/lexer/Lexer が `TokenStream` を生成する (これは `Token` のイテレータである。`TokenStream` は `Lexer::collect()` によって生成できる)

--- a/doc/JA/compiler/errors.md
+++ b/doc/JA/compiler/errors.md
@@ -1,5 +1,7 @@
 # Erg Compiler Errors
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/compiler/errors.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/compiler/errors.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 ## AssignError
 
 イミュータブル変数を書き換えようとすると発生します。

--- a/doc/JA/compiler/hir.md
+++ b/doc/JA/compiler/hir.md
@@ -1,5 +1,7 @@
 # 高レベル中間表現(HIR, High-level Intermediate Representation)
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/compiler/hir.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/compiler/hir.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 HIRはErgコンパイラがASTから生成する構造体です。
 この構造体にはソースコード中のあらゆる式の完全な型情報が含まれており、また構文糖が脱糖されています。
 ASTは(プレーンテキストとしての)ソースコードと一対一対応しますが、HIRは不要なコードの情報が除去されていたり、また省略された型情報が付記されたりしているため、HIRからソースコードを復元することは困難です。

--- a/doc/JA/compiler/index.md
+++ b/doc/JA/compiler/index.md
@@ -1,0 +1,2 @@
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/compiler/index.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/compiler/index.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+

--- a/doc/JA/compiler/inference.md
+++ b/doc/JA/compiler/inference.md
@@ -1,5 +1,7 @@
 # 型推論アルゴリズム
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/compiler/inference.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/compiler/inference.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 > __Warning__: この項は編集中であり、一部に間違いを含む可能性があります。
 
 以下で用いる表記方法を示します。

--- a/doc/JA/compiler/overview.md
+++ b/doc/JA/compiler/overview.md
@@ -1,5 +1,7 @@
 # `erg`の概観
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/compiler/overview.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/compiler/overview.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 各レイヤーの働きと特に重要な関数、メソッドを紹介します。
 
 ## 1. 字句解析

--- a/doc/JA/compiler/parsing.md
+++ b/doc/JA/compiler/parsing.md
@@ -1,5 +1,7 @@
 # Erg言語の構文解析
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/compiler/parsing.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/compiler/parsing.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 ## 空白の扱い
 
 Ergの文法において特異なのは、space-sensitive(空白による区別がある)である点である。

--- a/doc/JA/compiler/refinement_subtyping.md
+++ b/doc/JA/compiler/refinement_subtyping.md
@@ -1,5 +1,7 @@
 # 篩型
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/compiler/refinement_subtyping.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/compiler/refinement_subtyping.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 篩型とは、以下のような型である。
 
 ```python

--- a/doc/JA/compiler/trait_method_resolving.md
+++ b/doc/JA/compiler/trait_method_resolving.md
@@ -1,5 +1,7 @@
 # パッチメソッドの解決
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/compiler/trait_method_resolving.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/compiler/trait_method_resolving.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 `Nat`は0以上の`Int`、つまり`Int`のサブタイプである。
 本来`Nat`はPythonのクラス階層には存在しない。Ergはこのパッチのメソッドをどうやって解決するのだろうか？
 

--- a/doc/JA/compiler/transpile.md
+++ b/doc/JA/compiler/transpile.md
@@ -1,5 +1,7 @@
 # ErgコードはPythonコードにどのようにトランスパイルされるか？
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/compiler/transpile.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/compiler/transpile.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 正確には、ErgコードはPythonバイトコードにトランスパイルされます。
 しかしPythonバイトコードはほぼPythonコードに復元できるので、ここでは等価なPythonコードを例として上げています。
 ちなみに、ここで紹介する例は最適化レベルの低いものです。

--- a/doc/JA/compiler/type_var_normalization.md
+++ b/doc/JA/compiler/type_var_normalization.md
@@ -1,5 +1,7 @@
 # 正規化
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/compiler/type_var_normalization.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/compiler/type_var_normalization.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 * Ergの型引数正規化はSymPyのsimplify関数を参考にしています。
 
 例えば`concat: |T, M, N|([T; M], [T; N] -> [T; M+N])`を定義するとき、型変数・引数を具体化せずに一致判定を行わなくてはならない。

--- a/doc/JA/dev_guide/branches.md
+++ b/doc/JA/dev_guide/branches.md
@@ -1,5 +1,7 @@
 # ブランチの命名と運用方針
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/dev_guide/branches.md%26commit_hash%3Da711efa99b325ba1012f6897e7b0e2bdb947d8a1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/dev_guide/branches.md&commit_hash=a711efa99b325ba1012f6897e7b0e2bdb947d8a1)
+
 * 基本的に開発は`main`ブランチ一本で行う(モノレポ開発)。どうしてもブランチを切らないと作業しにくい場合のみ`feature-*`ブランチか`issue-*`ブランチを作成する。
 
 ## main

--- a/doc/JA/dev_guide/build_features.md
+++ b/doc/JA/dev_guide/build_features.md
@@ -1,5 +1,7 @@
 # `erg` build features
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/dev_guide/build_features.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/dev_guide/build_features.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 ## debug
 
 デバッグモードにする。これにより、Erg内部での挙動が逐次ログ表示される。

--- a/doc/JA/dev_guide/directories.md
+++ b/doc/JA/dev_guide/directories.md
@@ -1,5 +1,7 @@
 # Ergリポジトリのディレクトリ構造
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/dev_guide/directories.md%26commit_hash%3Da711efa99b325ba1012f6897e7b0e2bdb947d8a1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/dev_guide/directories.md&commit_hash=a711efa99b325ba1012f6897e7b0e2bdb947d8a1)
+
 ```console
  └─┬ assets: 画像など
    ├─ CODE_OF_CONDUCT: 行動規範

--- a/doc/JA/dev_guide/doc_guideline.md
+++ b/doc/JA/dev_guide/doc_guideline.md
@@ -1,5 +1,7 @@
 # 書式
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/dev_guide/doc_guideline.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/dev_guide/doc_guideline.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 以下のルールに従っていないドキュメントはすべて修正の対象となる。
 
 * コードコメント、または内部用のドキュメントは、である調で書く。

--- a/doc/JA/dev_guide/env.md
+++ b/doc/JA/dev_guide/env.md
@@ -1,5 +1,7 @@
 # 開発環境
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/dev_guide/env.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/dev_guide/env.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 ## インストールが必要なもの
 
 * Rust (installed with rustup)

--- a/doc/JA/dev_guide/faq_syntax.md
+++ b/doc/JA/dev_guide/faq_syntax.md
@@ -1,5 +1,7 @@
 # Erg design's "Why" and Answers
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/dev_guide/faq_syntax.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/dev_guide/faq_syntax.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 ## なぜ所有権システムがあるのにGCも共存させているのですか？
 
 Ergが所有権システムを導入した動機は、Rustのような「GCに頼らないメモリ管理」のためではないからです。

--- a/doc/JA/dev_guide/i18n_messages.md
+++ b/doc/JA/dev_guide/i18n_messages.md
@@ -1,5 +1,7 @@
 # メッセージの多言語化
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/dev_guide/i18n_messages.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/dev_guide/i18n_messages.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 Ergはメッセージ(スタート、オプション、ドキュメント、ヒント、警告、エラーメッセージなど)の多言語化を進めています。
 このプロジェクトは、RustやErgの詳しい知識がなくても参加することができます。ぜひ協力をお願いします。
 

--- a/doc/JA/dev_guide/index.md
+++ b/doc/JA/dev_guide/index.md
@@ -1,1 +1,3 @@
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/dev_guide/index.md%26commit_hash%3D7d43acdf0e2b71528b038b9a8e70be6c93831f96)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/dev_guide/index.md&commit_hash=7d43acdf0e2b71528b038b9a8e70be6c93831f96)
+

--- a/doc/JA/dev_guide/rust_code_guideline.md
+++ b/doc/JA/dev_guide/rust_code_guideline.md
@@ -1,5 +1,7 @@
 # Rustコードに関するガイドライン
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/dev_guide/rust_code_guideline.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/dev_guide/rust_code_guideline.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 ## ローカルルール
 
 * デバッグ用の出力には`log!`を使用する(release時にも必要な出力処理は`println!`等を使用する)。

--- a/doc/JA/dev_guide/terms.md
+++ b/doc/JA/dev_guide/terms.md
@@ -1,5 +1,7 @@
 # 用語辞典
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/dev_guide/terms.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/dev_guide/terms.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 ## 記号
 
 ### &excl;

--- a/doc/JA/dev_guide/unify_terms.md
+++ b/doc/JA/dev_guide/unify_terms.md
@@ -1,5 +1,7 @@
 # 用語の統一
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/dev_guide/unify_terms.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/dev_guide/unify_terms.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 ## Accessibility, Visibility (参照性、可視性)
 
 Visibility(可視性)を使用する。

--- a/doc/JA/faq_general.md
+++ b/doc/JA/faq_general.md
@@ -1,5 +1,7 @@
 # Erg FAQ
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/faq_general.md%26commit_hash%3Deccd113c1512076c367fb87ea73406f91ff83ba7)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/faq_general.md&commit_hash=eccd113c1512076c367fb87ea73406f91ff83ba7)
+
 このFAQは一般のErg入門者向けです。
 個別の(よくある)技術的な問題については[こちら](./faq_technical.md)を、文法の決定経緯(なぜこのような文法になったのか)などについては
 [こちら](./dev_guide/why.md)を参照してください。

--- a/doc/JA/faq_technical.md
+++ b/doc/JA/faq_technical.md
@@ -1,5 +1,7 @@
 # 技術的なFAQ
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/faq_technical.md%26commit_hash%3Dc120700585fdb1d655255c8e2817bb13cc8d369e)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/faq_technical.md&commit_hash=c120700585fdb1d655255c8e2817bb13cc8d369e)
+
 本項はErg言語を使用する上での技術的な質問に答えるものです。すなわち、WhatやWhichで始まる質問、Yes/Noで答えられる質問を載せています。
 
 根本的な文法の決定経緯については[こちら](./dev_guide/faq_syntax.md)を、なぜこの言語を作ったのか、この機能はどのように実装されているのかなど、より大きな話題は[こちら](./dev_guide/../faq_general.md)を参照してください。

--- a/doc/JA/improved_points.md
+++ b/doc/JA/improved_points.md
@@ -1,5 +1,7 @@
 # Pythonから改良された点
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/improved_points.md%26commit_hash%3Deccd113c1512076c367fb87ea73406f91ff83ba7)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/improved_points.md&commit_hash=eccd113c1512076c367fb87ea73406f91ff83ba7)
+
 ## 静的解析を行う(静的型チェック、変数・プロパティチェック)
 
 静的型チェックの恩恵は今更強調するまでもないほどですが、変数・プロパティの存在チェックもかなり効いてくる部分です。

--- a/doc/JA/index.md
+++ b/doc/JA/index.md
@@ -1,5 +1,7 @@
 # Index
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/index.md%26commit_hash%3Deccd113c1512076c367fb87ea73406f91ff83ba7)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/index.md&commit_hash=eccd113c1512076c367fb87ea73406f91ff83ba7)
+
 ## [API/](./API/index.md)
 
     Ergの組み込みまたは標準ライブラリで提供されるサブルーチン、型、定数等の仕様が記述されている。

--- a/doc/JA/migration_from_py.md
+++ b/doc/JA/migration_from_py.md
@@ -1,5 +1,7 @@
 # PythonからErgへの移行に関してのTips
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/migration_from_py.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/migration_from_py.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 ## 文字列をint等に変換したい
 
 `Str`クラスの`parse`メソッドを使用してください。これは`Result`型を返します。

--- a/doc/JA/python/bytecode_instructions.md
+++ b/doc/JA/python/bytecode_instructions.md
@@ -1,5 +1,7 @@
 # Python Bytecode Instructions
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/python/bytecode_instructions.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/python/bytecode_instructions.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 Python bytecodeの変数操作系の命令はnamei (name index)を通してアクセスされる。これは、Pythonの動的変数アクセス(evalなどを使い、文字列でアクセスできる)を実現するためである。
 1命令は2byteで、命令、引数がlittle endianで格納されている。
 引数を取らない命令も2byte使っている(引数部は0)。

--- a/doc/JA/python/bytecode_specification.md
+++ b/doc/JA/python/bytecode_specification.md
@@ -1,5 +1,7 @@
 # Python bytecode specification
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/python/bytecode_specification.md%26commit_hash%3D9f6a4a43fcf7e4f58cabe6e5a7546820fd9f5ff4)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/python/bytecode_specification.md&commit_hash=9f6a4a43fcf7e4f58cabe6e5a7546820fd9f5ff4)
+
 ## Format
 
 * 0~3 byte(u32): magic number (see common/bytecode.rs for details)

--- a/doc/JA/python/class_system.md
+++ b/doc/JA/python/class_system.md
@@ -1,5 +1,7 @@
 # Pythonのクラスシステム(Ergとの比較)
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/python/class_system.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/python/class_system.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 ## メソッド
 
 メソッドは前方参照していてもかまわないが、これは特別なテクニックが使われているわけではなく、

--- a/doc/JA/python/index.md
+++ b/doc/JA/python/index.md
@@ -1,0 +1,2 @@
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/python/index.md%26commit_hash%3D9f6a4a43fcf7e4f58cabe6e5a7546820fd9f5ff4)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/python/index.md&commit_hash=9f6a4a43fcf7e4f58cabe6e5a7546820fd9f5ff4)
+

--- a/doc/JA/syntax/00_basic.md
+++ b/doc/JA/syntax/00_basic.md
@@ -1,5 +1,7 @@
 # 基本事項
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/00_basic.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/00_basic.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 > __Warning__: 本ドキュメントは未完成です。校正(文体、正しいリンクが張られているか、など)がなされていません。また、Ergの文法はバージョン0.*の間に破壊的変更が加えられる可能性があり、それに伴うドキュメントの更新が追いついていない可能性があります。予めご了承ください。
 > また、本ドキュメントの誤りを見つけた場合は、[こちらのフォーム](https://forms.gle/HtLYRfYzWCAaeTGb6)または[GitHubリポジトリ](https://github.com/mtshiba/TheErgBook/issues/new)から修正の提案をしていただけると幸いです。
 

--- a/doc/JA/syntax/01_literal.md
+++ b/doc/JA/syntax/01_literal.md
@@ -1,5 +1,7 @@
 # Literal
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/01_literal.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/01_literal.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 ## 基本的なリテラル
 
 ### 整数リテラル(Int Literal)

--- a/doc/JA/syntax/02_name.md
+++ b/doc/JA/syntax/02_name.md
@@ -1,5 +1,7 @@
 # 変数
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/02_name.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/02_name.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 変数は代数の一種です。Ergにおける代数―紛れがなければ単に変数と呼ばれることもあります―とは、オブジェクトを名前付けしてコード中の別の場所から利用できるようにする機能を指します。
 
 変数は以下のように定義します。

--- a/doc/JA/syntax/03_declaration.md
+++ b/doc/JA/syntax/03_declaration.md
@@ -1,5 +1,7 @@
 # Declaration(宣言)
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/03_declaration.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/03_declaration.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 宣言は、使用する変数の型を指定する構文です。
 宣言はコード中のどこでも可能ですが、宣言しただけでその変数を参照することはできません。必ず初期化する必要があります。
 代入後の宣言では、代入されたオブジェクトと型が適合するかをチェック可能です。

--- a/doc/JA/syntax/04_function.md
+++ b/doc/JA/syntax/04_function.md
@@ -1,5 +1,7 @@
 # 関数
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/04_function.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/04_function.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 関数は「引数」を受け取ってそれを加工し、「戻り値」として返すブロックです。以下のように定義します。
 
 ```python

--- a/doc/JA/syntax/05_builtin_funcs.md
+++ b/doc/JA/syntax/05_builtin_funcs.md
@@ -1,5 +1,7 @@
 # 組み込み関数
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/05_builtin_funcs.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/05_builtin_funcs.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 ## if
 
 `if`は条件に応じて処理を変える関数です。

--- a/doc/JA/syntax/06_operator.md
+++ b/doc/JA/syntax/06_operator.md
@@ -1,5 +1,7 @@
 # 演算子
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/06_operator.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/06_operator.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 演算子(オペレーター)は、演算を表す記号です。被演算子(オペランド)は演算子の(左)右にあるもので、Ergでは専らオブジェクトです。
 
 演算子は関数の一種であり、したがってそれ自体も第一級オブジェクトで変数に束縛できます。束縛の際は``で囲む必要があります。

--- a/doc/JA/syntax/07_side_effect.md
+++ b/doc/JA/syntax/07_side_effect.md
@@ -1,5 +1,7 @@
 # 副作用とプロシージャ
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/07_side_effect.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/07_side_effect.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 これまで`print!`の`!`の意味を説明せずにいましたが、いよいよその意味が明かされます。この!は、ズバリこのオブジェクトが「副作用」のある「プロシージャ」であることを示しています。プロシージャは関数に「副作用」という効果を与えたものです。
 
 ```python

--- a/doc/JA/syntax/08_procedure.md
+++ b/doc/JA/syntax/08_procedure.md
@@ -1,5 +1,7 @@
 # プロシージャ
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/08_procedure.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/08_procedure.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 プロシージャは可変オブジェクトを取り扱う際に必要となりますが、可変オブジェクトを引数に持てばプロシージャであるとは限りません。
 
 ```python

--- a/doc/JA/syntax/09_builtin_procs.md
+++ b/doc/JA/syntax/09_builtin_procs.md
@@ -1,5 +1,7 @@
 # 組み込みプロシージャ
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/09_builtin_procs.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/09_builtin_procs.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 ## id!
 
 オブジェクトのユニークな識別番号を返します。

--- a/doc/JA/syntax/10_array.md
+++ b/doc/JA/syntax/10_array.md
@@ -1,5 +1,7 @@
 # 配列
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/10_array.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/10_array.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 配列はもっとも基本的な __コレクション(集約)__ です。
 コレクションとは、内部にオブジェクトを複数保持できるオブジェクトのことです。
 

--- a/doc/JA/syntax/11_tuple.md
+++ b/doc/JA/syntax/11_tuple.md
@@ -1,5 +1,7 @@
 # タプル
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/11_tuple.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/11_tuple.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 タプルは配列と似ていますが、違う型のオブジェクトを保持できます。
 このようなコレクションを非等質なコレクションと呼びます。対して等質なコレクションには配列、セットなどがあります。
 

--- a/doc/JA/syntax/12_dict.md
+++ b/doc/JA/syntax/12_dict.md
@@ -1,5 +1,7 @@
 # Dict
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/12_dict.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/12_dict.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 Dictはキーと値のペアを持つコレクションです。
 
 ```python

--- a/doc/JA/syntax/13_record.md
+++ b/doc/JA/syntax/13_record.md
@@ -1,5 +1,7 @@
 # レコード
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/13_record.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/13_record.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 レコードは、キーでアクセスするDictとコンパイル時にアクセスが検査されるタプルの性質を併せ持つコレクションです。
 JavaScriptをやったことがある方ならば、オブジェクトリテラル記法の(より強化された)ようなものと考えてください。
 

--- a/doc/JA/syntax/14_set.md
+++ b/doc/JA/syntax/14_set.md
@@ -1,5 +1,7 @@
 # セット(Set)
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/14_set.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/14_set.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 セットは集合を表し、データ構造的には重複、順序のない配列です。
 
 ```python

--- a/doc/JA/syntax/15_type.md
+++ b/doc/JA/syntax/15_type.md
@@ -1,5 +1,7 @@
 # 型
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/15_type.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/15_type.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 型はErgにおいて非常に重要な機能ですので、[専用のセクション](./type/01_type_system.md)を用意しています。そちらをご覧ください。
 
 <p align='center'>

--- a/doc/JA/syntax/16_iterator.md
+++ b/doc/JA/syntax/16_iterator.md
@@ -1,5 +1,7 @@
 # イテレータ
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/16_iterator.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/16_iterator.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 イテレータは、コンテナの要素を取り出すためのオブジェクトです。
 
 ```python

--- a/doc/JA/syntax/17_mutability.md
+++ b/doc/JA/syntax/17_mutability.md
@@ -1,5 +1,7 @@
 # Mutability
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/17_mutability.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/17_mutability.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 すでに見たように、Ergの変数は全て不変です。しかし、Ergのオブジェクトには可変性という概念があります。
 以下のコードを例にします。
 

--- a/doc/JA/syntax/18_ownership.md
+++ b/doc/JA/syntax/18_ownership.md
@@ -1,5 +1,7 @@
 # 所有権システム
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/18_ownership.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/18_ownership.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 ErgはPythonをホスト言語にした言語であるため、メモリ管理の方法はPythonの処理系に依存しています。
 しかし、意味論的にはErgのメモリ管理はPythonのそれとは別物です。顕著な違いは、所有権システムと循環参照の禁止に現れています。
 

--- a/doc/JA/syntax/19_visibility.md
+++ b/doc/JA/syntax/19_visibility.md
@@ -1,5 +1,7 @@
 # 可視性(Visibility)
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/19_visibility.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/19_visibility.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 Ergの変数には __可視性__ という概念が存在します。
 今まで見てきた変数は全て __プライベート変数(非公開変数)__ と呼ばれます。これは、外部から不可視の変数です。
 例えば`foo`モジュールで定義したプライベート変数は、別のモジュールから参照できないのです。

--- a/doc/JA/syntax/20_naming_rule.md
+++ b/doc/JA/syntax/20_naming_rule.md
@@ -1,5 +1,7 @@
 # 命名規則
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/20_naming_rule.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/20_naming_rule.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 変数を定数式として使いたい場合は、必ず大文字で始めます。二文字以降は小文字でもよいです。
 
 ```python

--- a/doc/JA/syntax/21_lambda.md
+++ b/doc/JA/syntax/21_lambda.md
@@ -1,5 +1,7 @@
 # 無名関数(anonymous function)
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/21_lambda.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/21_lambda.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 無名関数は、関数オブジェクトを名付けずその場で生成するための文法です。
 
 ```python

--- a/doc/JA/syntax/22_subroutine.md
+++ b/doc/JA/syntax/22_subroutine.md
@@ -1,5 +1,7 @@
 # Subroutine signatures
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/22_subroutine.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/22_subroutine.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 ## Func
 
 ```python

--- a/doc/JA/syntax/23_closure.md
+++ b/doc/JA/syntax/23_closure.md
@@ -1,5 +1,7 @@
 # クロージャ
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/23_closure.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/23_closure.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 Ergのサブルーチンには、外部変数を捕捉する「クロージャ」という機能があります。
 
 ```python

--- a/doc/JA/syntax/24_module.md
+++ b/doc/JA/syntax/24_module.md
@@ -1,5 +1,7 @@
 # モジュール
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/24_module.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/24_module.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 Ergでは、ファイル自体を1つのレコードとみなすことができます。これをモジュールと呼びます。
 
 ```python: foo.er

--- a/doc/JA/syntax/25_object_system.md
+++ b/doc/JA/syntax/25_object_system.md
@@ -1,5 +1,7 @@
 # Object(対象体)
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/25_object_system.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/25_object_system.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 変数に代入できる全てのデータです。`Object`クラスの持つ属性は以下の通りです。
 
 * `.__repr__`: オブジェクトの(リッチでない)文字列表現を返します

--- a/doc/JA/syntax/26_pattern_matching.md
+++ b/doc/JA/syntax/26_pattern_matching.md
@@ -1,5 +1,7 @@
 # パターンマッチ、論駁可能性
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/26_pattern_matching.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/26_pattern_matching.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 ## Ergで使用可能なパターン
 
 ### 変数パターン

--- a/doc/JA/syntax/27_comprehension.md
+++ b/doc/JA/syntax/27_comprehension.md
@@ -1,5 +1,7 @@
 # Comprehension(内包表記)
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/27_comprehension.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/27_comprehension.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 `[expr | (name <- iterable)+ (predicate)*]`で配列、
 `{expr | (name <- iterable)+ (predicate)*}`でセット、
 `{key: value | (name <- iterable)+ (predicate)*}`でDictが作れます。

--- a/doc/JA/syntax/28_spread_syntax.md
+++ b/doc/JA/syntax/28_spread_syntax.md
@@ -1,5 +1,7 @@
 # Spread assignment (展開代入)
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/28_spread_syntax.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/28_spread_syntax.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 分解代入において、変数の前に`...`を置くと残りの要素を全てその変数に展開できます。これを展開代入と呼びます。
 
 ```python

--- a/doc/JA/syntax/29_decorator.md
+++ b/doc/JA/syntax/29_decorator.md
@@ -1,5 +1,7 @@
 # デコレータ(修飾子)
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/29_decorator.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/29_decorator.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 デコレータは型や関数に特定の状態や振る舞いを追加したり明示するために使われます。
 デコレータの文法は以下の通りです。
 

--- a/doc/JA/syntax/30_error_handling.md
+++ b/doc/JA/syntax/30_error_handling.md
@@ -1,5 +1,7 @@
 # エラーハンドリングシステム
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/30_error_handling.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/30_error_handling.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 主にResult型を使用します。
 ErgではError型オブジェクトを捨てる(トップレベルで対応しない)とエラーが発生します。
 

--- a/doc/JA/syntax/31_pipeline.md
+++ b/doc/JA/syntax/31_pipeline.md
@@ -1,5 +1,7 @@
 # パイプライン演算子
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/31_pipeline.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/31_pipeline.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 パイプライン演算子は、次のように使います。
 
 ```python

--- a/doc/JA/syntax/32_integration_with_Python.md
+++ b/doc/JA/syntax/32_integration_with_Python.md
@@ -1,5 +1,7 @@
 # Pythonとの連携
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/32_integration_with_Python.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/32_integration_with_Python.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 ## Pythonへのexport
 
 Ergスクリプトをコンパイルすると.pycファイルが生成されますが、これは単純にPythonのモジュールとして読み込むことができます。

--- a/doc/JA/syntax/33_package_system.md
+++ b/doc/JA/syntax/33_package_system.md
@@ -1,5 +1,7 @@
 # パッケージシステム
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/33_package_system.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/33_package_system.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 Ergのパッケージはアプリケーションであるappパッケージとライブラリであるlibパッケージに大別できます。
 appパッケージのエントリポイントは`src/app.er`です。`app.er`内に定義された`main`関数が実行されます。
 libパッケージのエントリポイントは`src/lib.er`です。パッケージをインポートすることは`lib.er`をインポートすることと等価になります。

--- a/doc/JA/syntax/34_generator.md
+++ b/doc/JA/syntax/34_generator.md
@@ -1,5 +1,7 @@
 # ジェネレータ
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/34_generator.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/34_generator.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 ジェネレータは、ブロック中で`yield!`プロシージャを使う特殊なプロシージャです。
 
 ```python

--- a/doc/JA/syntax/SUMMARY.md
+++ b/doc/JA/syntax/SUMMARY.md
@@ -1,5 +1,7 @@
 # Summary
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/SUMMARY.md%26commit_hash%3D2ce482b1c8407332b3b74f4c3e5596f373f9a657)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/SUMMARY.md&commit_hash=2ce482b1c8407332b3b74f4c3e5596f373f9a657)
+
 - [Basics](./00_basic.md)
 - [Literal](./01_literal.md)
 - [Name](02_name.md)

--- a/doc/JA/syntax/container_ownership.md
+++ b/doc/JA/syntax/container_ownership.md
@@ -1,5 +1,7 @@
 # Subscript(添字アクセス)
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/container_ownership.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/container_ownership.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 `[]`は通常のメソッドとは異なっています。
 
 ```python

--- a/doc/JA/syntax/indexes.md
+++ b/doc/JA/syntax/indexes.md
@@ -1,5 +1,7 @@
 # 索引
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/indexes.md%26commit_hash%3D438bcb89ea692f219b30f3a3ba107888b23eae98)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/indexes.md&commit_hash=438bcb89ea692f219b30f3a3ba107888b23eae98)
+
 この索引にないAPIについては[こちら](../API/index.md)を参照してください。
 用語の意味については[こちら](../dev_guide/terms.md)を参照。
 

--- a/doc/JA/syntax/quick_tour.md
+++ b/doc/JA/syntax/quick_tour.md
@@ -1,5 +1,7 @@
 # Quick Tour
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/quick_tour.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/quick_tour.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 `syntax`以下のドキュメントは、概ねプログラミング初心者でも理解できることを目指して書かれています。
 すでにPythonやRust, Haskellなどの言語を習得されている方にとっては、少し冗長であるかもしれません。
 

--- a/doc/JA/syntax/type/01_type_system.md
+++ b/doc/JA/syntax/type/01_type_system.md
@@ -1,5 +1,7 @@
 # Ergの型システム
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/01_type_system.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/01_type_system.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 以下では、Ergの型システムを概略的に説明します。詳細については他の項で解説します。
 
 ## 定義方法

--- a/doc/JA/syntax/type/02_basic.md
+++ b/doc/JA/syntax/type/02_basic.md
@@ -1,5 +1,7 @@
 # 型に関する基本的な文法
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/02_basic.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/02_basic.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 ## 型指定
 
 Ergでは以下のように`:`の後に変数の型を指定します。代入と同時に行うこともできます。

--- a/doc/JA/syntax/type/03_trait.md
+++ b/doc/JA/syntax/type/03_trait.md
@@ -1,5 +1,7 @@
 # トレイト
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/03_trait.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/03_trait.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 トレイトは、レコード型に型属性の要求を追加した記名型です。
 Pythonでいう抽象基底クラス(Abstract Base Class, ABC)に類似しますが、代数的演算を行えるという特徴があります。
 

--- a/doc/JA/syntax/type/04_class.md
+++ b/doc/JA/syntax/type/04_class.md
@@ -1,5 +1,7 @@
 # Class
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/04_class.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/04_class.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 Ergにおけるクラスは、大まかには自身の要素(インスタンス)を生成できる型と言えます。
 以下は単純なクラスの例です。
 

--- a/doc/JA/syntax/type/05_inheritance.md
+++ b/doc/JA/syntax/type/05_inheritance.md
@@ -1,5 +1,7 @@
 # 継承(Inheritance)
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/05_inheritance.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/05_inheritance.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 継承を使うと、既存のクラスに機能を加えたり特化したりした新しいクラスを定義できます。
 継承はトレイトにおける包摂に似ています。継承してできたクラスは、もとのクラスのサブタイプになります。
 

--- a/doc/JA/syntax/type/06_nst_vs_sst.md
+++ b/doc/JA/syntax/type/06_nst_vs_sst.md
@@ -1,5 +1,7 @@
 # 記名的部分型 vs. 構造的部分型
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/06_nst_vs_sst.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/06_nst_vs_sst.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 ```python
 Months = 0..12
 

--- a/doc/JA/syntax/type/07_patch.md
+++ b/doc/JA/syntax/type/07_patch.md
@@ -1,5 +1,7 @@
 # Patch
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/07_patch.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/07_patch.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 Ergでは、既存の型・クラスに手を加えることはできません。
 クラスにメソッドを追加で定義することはできず、特殊化(specialization, 多相に宣言された型を単相化し専用のメソッドを定義する機能。C++などが持つ)も行えません。
 しかし、既存の型・クラスに機能を追加したいという状況は多々あり、これを実現するためにパッチという機能があります。

--- a/doc/JA/syntax/type/08_value.md
+++ b/doc/JA/syntax/type/08_value.md
@@ -1,5 +1,7 @@
 # 値型(Value types)
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/08_value.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/08_value.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 値型はErg組み込み型のうちコンパイル時評価が可能な型で、具体的には以下のものです。
 
 ```python

--- a/doc/JA/syntax/type/09_attributive.md
+++ b/doc/JA/syntax/type/09_attributive.md
@@ -1,5 +1,7 @@
 # 属性型(Attributive Type)
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/09_attributive.md%26commit_hash%3Deccd113c1512076c367fb87ea73406f91ff83ba7)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/09_attributive.md&commit_hash=eccd113c1512076c367fb87ea73406f91ff83ba7)
+
 属性型は、レコードおよびデータクラス、パッチ、モジュールなどが含まれる型です。
 属性型に属する型は値型ではありません。
 

--- a/doc/JA/syntax/type/10_interval.md
+++ b/doc/JA/syntax/type/10_interval.md
@@ -1,5 +1,7 @@
 # Interval Type
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/10_interval.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/10_interval.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 `Range`オブジェクトの最も基本的な使い方は、イテレータとしての使用です。
 
 ```python

--- a/doc/JA/syntax/type/11_enum.md
+++ b/doc/JA/syntax/type/11_enum.md
@@ -1,5 +1,7 @@
 # Enumerative Type(列挙型)
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/11_enum.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/11_enum.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 列挙型(Enum type)はSetによって生成されます。
 列挙型はそのままでも型指定で使えますが、クラス化したりパッチを定義することで更にメソッドを定義できます。
 列挙型による部分型システムを列挙的部分型付けといいます。

--- a/doc/JA/syntax/type/12_refinement.md
+++ b/doc/JA/syntax/type/12_refinement.md
@@ -1,5 +1,7 @@
 # 篩型(Refinement Type)
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/12_refinement.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/12_refinement.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 Refinement type(篩型、ふるいがた)は、述語式によって制約付けられた型です。列挙型や区間型は篩型の一種です。
 
 篩型の標準形は`{Elem: Type | (Pred)*}`です。これは、`Pred`を満たす`Elem`を要素とする型である、という意味です。

--- a/doc/JA/syntax/type/13_algebraic.md
+++ b/doc/JA/syntax/type/13_algebraic.md
@@ -1,5 +1,7 @@
 # Algebraic type (代数演算型)
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/13_algebraic.md%26commit_hash%3Dc120700585fdb1d655255c8e2817bb13cc8d369e)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/13_algebraic.md&commit_hash=c120700585fdb1d655255c8e2817bb13cc8d369e)
+
 代数演算型は、型を代数のようにみなして演算することで生成される型のことです。
 代数演算型が扱う演算は、Union, Intersection, Diff, Complementなどがあります。
 通常のクラスはUnionのみが行えて、他の演算は型エラーになります。

--- a/doc/JA/syntax/type/14_dependent.md
+++ b/doc/JA/syntax/type/14_dependent.md
@@ -1,5 +1,7 @@
 # 依存型
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/14_dependent.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/14_dependent.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 依存型はErgの最大の特徴とも言っても良い機能です。
 依存型とは、値を引数に取る型です。通常の多相型は型のみを引数に取れますが、その制限を緩めたのが依存型といえます。
 

--- a/doc/JA/syntax/type/15_quantified.md
+++ b/doc/JA/syntax/type/15_quantified.md
@@ -1,5 +1,7 @@
 # 型変数(Type Variable)、量化型
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/15_quantified.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/15_quantified.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 型変数はサブルーチン引数の型指定などに使用する変数で、その型が任意である(単相化しない)ことを示します。
 まず、型変数を導入するモチベーションとして、入力をそのまま返す`id`関数について考えましょう。
 

--- a/doc/JA/syntax/type/16_subtyping.md
+++ b/doc/JA/syntax/type/16_subtyping.md
@@ -1,5 +1,7 @@
 # 部分型付け
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/16_subtyping.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/16_subtyping.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 Ergでは、クラス同士の包含関係は比較演算子`<`, `>`で判定可能です。
 
 ```python

--- a/doc/JA/syntax/type/17_type_casting.md
+++ b/doc/JA/syntax/type/17_type_casting.md
@@ -1,5 +1,7 @@
 # キャスト
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/17_type_casting.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/17_type_casting.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 ## アップキャスト
 
 Pythonはダックタイピングを採用する言語のため、キャストという概念はありません。アップキャストはする必要がなく、ダウンキャストも基本的にはありません。

--- a/doc/JA/syntax/type/18_mut.md
+++ b/doc/JA/syntax/type/18_mut.md
@@ -1,5 +1,7 @@
 # 可変型(Mutable Type)
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/18_mut.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/18_mut.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 > __Warning__: この項の情報は古く、一部に間違いを含みます。
 
 Ergではデフォルトですべての型が不変型、すなわち内部状態を更新できないようになっています。

--- a/doc/JA/syntax/type/19_bound.md
+++ b/doc/JA/syntax/type/19_bound.md
@@ -1,5 +1,7 @@
 # 型境界 (Type Bound)
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/19_bound.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/19_bound.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 型境界は型指定に条件を加えるものである。これを実現する機能がガード(ガード節)である。
 関数シグニチャ、無名関数シグニチャのほか、篩型でもこの機能を利用できる。
 ガードは戻り値型の後に記述する。

--- a/doc/JA/syntax/type/advanced.md
+++ b/doc/JA/syntax/type/advanced.md
@@ -1,2 +1,4 @@
 以降は更に高度な型システムを解説します。入門者の方はすべての項を読まなくても問題ありません。
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/advanced.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/advanced.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+

--- a/doc/JA/syntax/type/advanced/GADTs.md
+++ b/doc/JA/syntax/type/advanced/GADTs.md
@@ -1,5 +1,7 @@
 # 一般化代数的データ型(Generalized Algebraic Data Types, GADTs)
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/advanced/GADTs.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/advanced/GADTs.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 ErgはOr型をクラス化することで一般化代数的データ型(GADTs)を作成出来ます。
 
 ```python

--- a/doc/JA/syntax/type/advanced/_rank2type.md
+++ b/doc/JA/syntax/type/advanced/_rank2type.md
@@ -1,5 +1,7 @@
 # rank-2多相
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/advanced/_rank2type.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/advanced/_rank2type.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 > __Warning__: このドキュメントは情報が古く、全般に間違いを含みます。
 
 Ergでは`id|T|(x: T): T = x`などのように色々な型を受け取れる関数、すなわち多相関数を定義できる。

--- a/doc/JA/syntax/type/advanced/default_param.md
+++ b/doc/JA/syntax/type/advanced/default_param.md
@@ -1,5 +1,7 @@
 # デフォルト引数付きの関数型
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/advanced/default_param.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/advanced/default_param.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 まず、デフォルト引数の使用例を見る。
 
 ```python

--- a/doc/JA/syntax/type/advanced/erasure.md
+++ b/doc/JA/syntax/type/advanced/erasure.md
@@ -1,5 +1,7 @@
 # 型消去(Type erasure)
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/advanced/erasure.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/advanced/erasure.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 型消去とは、型引数に`_`を指定し、その情報をあえて捨てることです。型消去は多相型を持つ言語の多くが併せて持つ機能ですが、Ergの文法に即して言えば型引数消去といった方が正確でしょう。
 
 もっともよく見られる型消去された型の例は`[T, _]`でしょう。配列はコンパイル時にその長さが分からない場合もあります。例えば、コマンドライン引数を指す`sys.argv`は`[Str, _]`型です。コマンドライン引数の長さをErgのコンパイラは知りようがないため、長さに関する情報は諦めなくてはならないのです。

--- a/doc/JA/syntax/type/advanced/existential.md
+++ b/doc/JA/syntax/type/advanced/existential.md
@@ -1,5 +1,7 @@
 # 存在型
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/advanced/existential.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/advanced/existential.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 ∀に対応する全称型があるならば、∃に対応する存在型があると考えるのが自然です。
 存在型は難しいものではありません。そうと意識していないだけで、既にあなたは存在型を知っています。
 

--- a/doc/JA/syntax/type/advanced/keyword_param.md
+++ b/doc/JA/syntax/type/advanced/keyword_param.md
@@ -1,5 +1,7 @@
 # キーワード引数付き関数型
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/advanced/keyword_param.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/advanced/keyword_param.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 ```python
 h(f) = f(y: 1, x: 2)
 h: |T: Type|((y: Int, x: Int) -> T) -> T

--- a/doc/JA/syntax/type/advanced/kind.md
+++ b/doc/JA/syntax/type/advanced/kind.md
@@ -1,5 +1,7 @@
 # カインド(Kind)
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/advanced/kind.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/advanced/kind.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 Ergでは全てが型付けられている。型自体も例外ではない。「型の型」を表すのが __カインド(種)__ である。例えば`1`が`Int`に属しているように、`Int`は`Type`に属している。`Type`は最もシンプルなカインドである __原子カインド(Atomic kind)__ である。型理論的の記法では、`Type`は`*`に対応する。
 
 カインドという概念で実用上重要なのは1項以上のカインド(多項カインド)である。1項のカインドは、例えば`Option`などがそれに属する。1項カインドは`Type -> Type`と表される[<sup id="f1">1</sup>](#1)。`Array`や`Option`などの __コンテナ__ は特に型を引数に取る多項カインドのことなのである。

--- a/doc/JA/syntax/type/advanced/marker_trait.md
+++ b/doc/JA/syntax/type/advanced/marker_trait.md
@@ -1,5 +1,7 @@
 # Marker Trait
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/advanced/marker_trait.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/advanced/marker_trait.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 マーカートレイトは、要求属性のないトレイトである。すなわち、メソッドを実装せずにImplすることができる。
 要求属性がないと意味がないように思えるが、そのトレイトに属しているという情報が登録されるので、パッチメソッドを使ったり、コンパイラが特別扱いしたりできる。
 

--- a/doc/JA/syntax/type/advanced/mut_struct.md
+++ b/doc/JA/syntax/type/advanced/mut_struct.md
@@ -1,5 +1,7 @@
 # 可変構造型
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/advanced/mut_struct.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/advanced/mut_struct.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 `T!`型は任意の`T`型オブジェクトを入れられて差し替え可能なボックス型であると説明した。
 
 ```python

--- a/doc/JA/syntax/type/advanced/newtype.md
+++ b/doc/JA/syntax/type/advanced/newtype.md
@@ -1,5 +1,7 @@
 # Newtype pattern
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/advanced/newtype.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/advanced/newtype.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 ここでは、Rustでよく使われるnewtypeパターンのErg版を紹介します。
 
 Ergはでは以下のように型のエイリアスを定義できますが、これはあくまで同じ型を指します。

--- a/doc/JA/syntax/type/advanced/overloading.md
+++ b/doc/JA/syntax/type/advanced/overloading.md
@@ -1,5 +1,7 @@
 # オーバーロード
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/advanced/overloading.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/advanced/overloading.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 Ergでは __アドホック多相__ をサポートしない。すなわち、関数・カインドの多重定義(オーバーロード)ができない。が、トレイトクラスとパッチを組み合わせることでオーバーロードの挙動を再現できる。
 トレイトクラスのかわりにトレイトを使用しても良いが、その場合`.add1`を実装している型全てが対象になってしまう。
 

--- a/doc/JA/syntax/type/advanced/phantom.md
+++ b/doc/JA/syntax/type/advanced/phantom.md
@@ -1,5 +1,7 @@
 # 幽霊型(Phantom class)
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/advanced/phantom.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/advanced/phantom.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 幽霊型は、コンパイラに注釈を与えるためだけに存在するマーカートレイトである。
 幽霊型の使い方として、リストの構成をみる。
 

--- a/doc/JA/syntax/type/advanced/projection.md
+++ b/doc/JA/syntax/type/advanced/projection.md
@@ -1,5 +1,7 @@
 # Projection Type(射影型)
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/advanced/projection.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/advanced/projection.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 射影型は、次のコードにおける`Self.AddO`のような型を表します。
 
 ```python

--- a/doc/JA/syntax/type/advanced/quantified_dependent.md
+++ b/doc/JA/syntax/type/advanced/quantified_dependent.md
@@ -1,5 +1,7 @@
 # 量化依存型
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/advanced/quantified_dependent.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/advanced/quantified_dependent.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 Ergには量化型、依存型が存在します。すると当然、その二つを組み合わせた型を作ることができます。それが量化依存型です。
 
 ```python

--- a/doc/JA/syntax/type/advanced/shared.md
+++ b/doc/JA/syntax/type/advanced/shared.md
@@ -1,5 +1,7 @@
 # 共有参照(Shared Reference)
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/advanced/shared.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/advanced/shared.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 共有参照は気をつけて扱わねばならない言語機能の一つです。
 例えばTypeScriptでは以下のようなコードが型検査を通ってしまいます。
 

--- a/doc/JA/syntax/type/advanced/special.md
+++ b/doc/JA/syntax/type/advanced/special.md
@@ -1,5 +1,7 @@
 # 特殊型(Self, Super)
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/advanced/special.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/advanced/special.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 `Self`は自身の型を表します。単にエイリアスとして使うことも出来ますが、派生型中では意味が変わる(自身の型を指す)ので注意してください。
 
 ```python

--- a/doc/JA/syntax/type/advanced/typeof.md
+++ b/doc/JA/syntax/type/advanced/typeof.md
@@ -1,5 +1,7 @@
 # Typeof, classof
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/advanced/typeof.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/advanced/typeof.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 `Typeof`はErgの型推論システムを覗くことができる関数であり、その挙動は複雑である。
 
 ```python

--- a/doc/JA/syntax/type/advanced/variance.md
+++ b/doc/JA/syntax/type/advanced/variance.md
@@ -1,5 +1,7 @@
 # 変性(variance)
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/advanced/variance.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/advanced/variance.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 Ergは多相型のサブタイピングを行えるが、一部注意しなくてはならない点がある。
 
 まずは通常の多相型の包含関係を考える。一般に、コンテナ`K`と代入する型`A, B`があり、`A < B`のとき、`K A < K B`となる。

--- a/doc/JA/syntax/type/advanced/widening.md
+++ b/doc/JA/syntax/type/advanced/widening.md
@@ -1,5 +1,7 @@
 # 型拡大(Type Widening)
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/advanced/widening.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/advanced/widening.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 例えば以下のような多相関数を定義する。
 
 ```python

--- a/doc/JA/tips.md
+++ b/doc/JA/tips.md
@@ -1,5 +1,7 @@
 # Tips
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/tips.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/tips.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 ## エラーの表示言語を変えたい
 
 各国語版のergをダウンロードしてください。

--- a/doc/JA/tools/build.md
+++ b/doc/JA/tools/build.md
@@ -1,5 +1,7 @@
 # buildサブコマンド
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/tools/build.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/tools/build.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 buildサブコマンドでは、パッケージのビルドを行います。
 デフォルトのビルドで行われる工程は、以下の通りです。
 

--- a/doc/JA/tools/env.md
+++ b/doc/JA/tools/env.md
@@ -1,5 +1,7 @@
 # envサブコマンド
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/tools/env.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/tools/env.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 envサブコマンドはerg実行環境の指定を行います。
 `erg env new [env name]`で新しい実行環境を作成します。対話ツールが開き、ergのバージョンを指定すると、そのバージョンのergがインストール(すでにあれば流用されます)され、新しい環境として使えるようになります。
 `erg env switch [env name]`で環境の切り替えができます。

--- a/doc/JA/tools/fmt.md
+++ b/doc/JA/tools/fmt.md
@@ -1,5 +1,7 @@
 # fmt
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/tools/fmt.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/tools/fmt.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 fmtサブコマンドででコードフォーマットが出来ます。
 よく使用されるフラッグは以下の通りです。
 

--- a/doc/JA/tools/index.md
+++ b/doc/JA/tools/index.md
@@ -1,0 +1,2 @@
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/tools/index.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/tools/index.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+

--- a/doc/JA/tools/install.md
+++ b/doc/JA/tools/install.md
@@ -1,5 +1,7 @@
 # installサブコマンド
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/tools/install.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/tools/install.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 installでレジストリサイトに登録されたパッケージをインストールできる。
 基本的な使い方はcargoなどのパッケージマネージャと同じ。
 

--- a/doc/JA/tools/pack.md
+++ b/doc/JA/tools/pack.md
@@ -1,5 +1,7 @@
 # パッケージマネージャー
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/tools/pack.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/tools/pack.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 Ergは標準でパッケージマネージャーが付属しており、`pack`サブコマンドで呼び出せる。
 以下は典型的なオプションである。
 

--- a/doc/JA/tools/repl.md
+++ b/doc/JA/tools/repl.md
@@ -1,5 +1,7 @@
 # REPL
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/tools/repl.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/tools/repl.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 `erg`コマンドを引数を与えず実行すると、REPLが起動されます。また、`repl`サブコマンドを指定して起動することもできます。
 さらに以下のフラグを指定できます。
 

--- a/doc/JA/tools/test.md
+++ b/doc/JA/tools/test.md
@@ -1,5 +1,7 @@
 # testサブコマンド
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/tools/test.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/tools/test.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 ergコマンドにはtestというサブコマンドがあり、テスト実装、及び実行の支援を行う。
 
 ## Testデコレータ(@Test)

--- a/doc/zh_CN/API/consts.md
+++ b/doc/zh_CN/API/consts.md
@@ -1,5 +1,7 @@
 # 内置常量
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/consts.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/consts.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 ## True
 
 ## False

--- a/doc/zh_CN/API/funcs.md
+++ b/doc/zh_CN/API/funcs.md
@@ -1,5 +1,7 @@
 # 功能
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/funcs.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/funcs.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 ## 基本功能
 
 ### if|T; U|(cond: Bool, then: T, else: U) -> T or U

--- a/doc/zh_CN/API/index.md
+++ b/doc/zh_CN/API/index.md
@@ -1,0 +1,2 @@
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/index.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/index.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+

--- a/doc/zh_CN/API/modules/external/alstruct.md
+++ b/doc/zh_CN/API/modules/external/alstruct.md
@@ -1,5 +1,7 @@
 # 结构
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/modules/external/alstruct.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/modules/external/alstruct.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 模块为它们提供代表代数结构和补丁的特征
 
 * 成员

--- a/doc/zh_CN/API/modules/repl.md
+++ b/doc/zh_CN/API/modules/repl.md
@@ -1,5 +1,7 @@
 # 模块`repl`
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/modules/repl.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/modules/repl.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 提供REPL(Read-Eval-Print-Loop)相关的API。
 
 ## 功能

--- a/doc/zh_CN/API/modules/status.md
+++ b/doc/zh_CN/API/modules/status.md
@@ -1,5 +1,7 @@
  # 模块`status`
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/modules/status.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/modules/status.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 定义了一个类型来表示状态。请根据情况删除选项来使用它
 
 * ExecResult = {"success", "warning", "failure", "fatal", "unknown"}

--- a/doc/zh_CN/API/modules/unit.md
+++ b/doc/zh_CN/API/modules/unit.md
@@ -1,5 +1,7 @@
 # 模块`unit`
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/modules/unit.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/modules/unit.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 `unit` 模块是将数值计算中经常使用的单位定义为类型的模块。
 Erg 数值类型包括 `Nat`、`Int`、`Ratio` 等。但是，这些类型没有关于“数字的含义”的信息，因此可以执行诸如添加米和码之类的无意义计算。
 通过使用 `unit` 模块，您可以避免错误，例如将不同单位的数字传递给函数。

--- a/doc/zh_CN/API/modules/unsound.md
+++ b/doc/zh_CN/API/modules/unsound.md
@@ -1,5 +1,7 @@
 # 模块 `unsound`
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/modules/unsound.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/modules/unsound.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 让 API 执行在 Erg 的类型系统中无法保证的不健全和不安全的操作。
 
 ## `unsafe!`

--- a/doc/zh_CN/API/operators.md
+++ b/doc/zh_CN/API/operators.md
@@ -1,5 +1,7 @@
 # 操作员
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/operators.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/operators.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 ## 中缀运算符
 
 ### `_+_`|R; O; A <: Add(R, O)|(x: A, y: R) -> O

--- a/doc/zh_CN/API/procs.md
+++ b/doc/zh_CN/API/procs.md
@@ -1,5 +1,7 @@
 # 过程
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/procs.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/procs.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 ## print!
 
 ```python

--- a/doc/zh_CN/API/special.md
+++ b/doc/zh_CN/API/special.md
@@ -1,5 +1,7 @@
 # 特殊形式
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/special.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/special.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 特殊形式是不能在 Erg 类型系统中表达的运算符、子程序(等等)。它被`包围，但实际上无法捕获。
 此外，为方便起见，还出现了“Pattern”、“Body”和“Conv”等类型，但不存在此类类型。它的含义也取决于上下文。
 

--- a/doc/zh_CN/API/types.md
+++ b/doc/zh_CN/API/types.md
@@ -1,5 +1,7 @@
 # 内置 Erg 类型列表
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 类型本身的属性不存储在 `.__dict__` 中，不能从实例中引用
 
 ## 基本类型

--- a/doc/zh_CN/API/types/classes/Array!(T).md
+++ b/doc/zh_CN/API/types/classes/Array!(T).md
@@ -1,3 +1,5 @@
 # Array! T
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Array!(T).md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Array!(T).md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 表示可变长度数组的类型。在编译时长度未知时使用。 有一个语法糖叫做` [t]!`。在`Array! T = ArrayWithMutLength! T, !_`中被定义

--- a/doc/zh_CN/API/types/classes/Array(T).md
+++ b/doc/zh_CN/API/types/classes/Array(T).md
@@ -1,3 +1,5 @@
 # Array T: Type
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Array(T).md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Array(T).md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 由`Array T = ArrayWithLen T, _`定义。 有一种语法糖叫做`[T]`。

--- a/doc/zh_CN/API/types/classes/ArrayWithLen(T,N).md
+++ b/doc/zh_CN/API/types/classes/ArrayWithLen(T,N).md
@@ -1,5 +1,7 @@
 # ArrayWithLen T: Type, N: Nat
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/ArrayWithLen(T,N).md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/ArrayWithLen(T,N).md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 `[T; N]`是语法糖。还有一个[`Array` 类型](./Array.md)省略了长度。
 
 ## 方法

--- a/doc/zh_CN/API/types/classes/ArrayWithMutLength!(T,N).md
+++ b/doc/zh_CN/API/types/classes/ArrayWithMutLength!(T,N).md
@@ -1,5 +1,7 @@
 # ArrayWithMutLength! T: Type, N: Nat&excl;
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/ArrayWithMutLength!(T,N).md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/ArrayWithMutLength!(T,N).md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 一个可变长度数组，其长度在编译时已知。还有语法糖`ArrayWithMutLength(T, !N) == [T; !N]`
 
 ## 方法

--- a/doc/zh_CN/API/types/classes/Class.md
+++ b/doc/zh_CN/API/types/classes/Class.md
@@ -1,0 +1,2 @@
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Class.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Class.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+

--- a/doc/zh_CN/API/types/classes/Complex.md
+++ b/doc/zh_CN/API/types/classes/Complex.md
@@ -1,5 +1,7 @@
 # Complex
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Complex.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Complex.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 表示复数的类型。在 Erg 中表示数字的类型，例如 Float、Int和Nat，通常派生于Complex
 
 ## 父类

--- a/doc/zh_CN/API/types/classes/Dict!.md
+++ b/doc/zh_CN/API/types/classes/Dict!.md
@@ -1,5 +1,7 @@
 # Dict! K, V
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Dict!.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Dict!.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 表示字典(哈希Map)的类型。 有一个语法糖叫做`{K: V}`
 
 ## 方法

--- a/doc/zh_CN/API/types/classes/Either.md
+++ b/doc/zh_CN/API/types/classes/Either.md
@@ -1,5 +1,7 @@
 # Either L, R = L or R
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Either.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Either.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 表示L或R的类型。 您可以将其视为Or类型的二元形式
 
 ## 方法

--- a/doc/zh_CN/API/types/classes/Float.md
+++ b/doc/zh_CN/API/types/classes/Float.md
@@ -1,5 +1,7 @@
 # Float size
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Float.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Float.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 表示实数(包含小数的数)的类型。符合IEEE 754的浮点数，在其他语言中一般是float的类型。
 Float的大小为8(1byte)~128(16byte)。如果只是Float，则表示`Float64`。
 Erg 中的 0.1 实际上属于 Ratio 类型，而不是 Float 类型。没有浮点类型字面量，它是由 `(Ratio object)f64` 生成的(例如 (1/2)f64, 15f64)。 f64 对应实数 1

--- a/doc/zh_CN/API/types/classes/Function(N).md
+++ b/doc/zh_CN/API/types/classes/Function(N).md
@@ -1,5 +1,7 @@
 # Function N: Nat
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Function(N).md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Function(N).md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 ## Function 1 的方法
 
 * then(self, g: Self) -> Self

--- a/doc/zh_CN/API/types/classes/Inf.md
+++ b/doc/zh_CN/API/types/classes/Inf.md
@@ -1,5 +1,7 @@
 # Inf
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Inf.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Inf.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 Inf是一个类，其唯一实例是inf。
 inf的主要用途是用于区间类型。
 例如，大于等于 2 的整数类型是 `2..<inf`，小于等于 0 的实数是 `-inf<..0.0`。

--- a/doc/zh_CN/API/types/classes/Int.md
+++ b/doc/zh_CN/API/types/classes/Int.md
@@ -1,5 +1,7 @@
 # Int
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Int.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Int.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 表示整数的类。 实例为 0、1、-1、300000 等。
 很多语言即使在表示自然数的时候也使用Int(类型等价于)，但是Erg使用了使用更小的类型的原则，
 建议使用 Nat、NZInt、Interval 类型等。

--- a/doc/zh_CN/API/types/classes/IntRange.md
+++ b/doc/zh_CN/API/types/classes/IntRange.md
@@ -1,5 +1,7 @@
 # IntRange L, R
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/IntRange.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/IntRange.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 `L..R`のクラス。
 
 ```python

--- a/doc/zh_CN/API/types/classes/Interval.md
+++ b/doc/zh_CN/API/types/classes/Interval.md
@@ -1,5 +1,7 @@
 # Interval begin, end := WellOrder
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Interval.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Interval.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 表示有序集合类型 (WellOrder) 的子类型的类型。Interval 类型具有派生类型，例如 PreOpen(x<..y)。
 
 ```python

--- a/doc/zh_CN/API/types/classes/Iterator.md
+++ b/doc/zh_CN/API/types/classes/Iterator.md
@@ -1,0 +1,2 @@
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Iterator.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Iterator.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+

--- a/doc/zh_CN/API/types/classes/Kind(N).md
+++ b/doc/zh_CN/API/types/classes/Kind(N).md
@@ -1,5 +1,7 @@
 # Kind N: Nat
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Kind(N).md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Kind(N).md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 ```python
 Kind N: Nat = (Type; N) -> Type
 ```

--- a/doc/zh_CN/API/types/classes/Matrix.md
+++ b/doc/zh_CN/API/types/classes/Matrix.md
@@ -1,5 +1,7 @@
 # Matrix T: Num, Shape: [M, N]
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Matrix.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Matrix.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 表示矩阵的类型。 它继承自 Tensor[M, N]
 
 ## 定义

--- a/doc/zh_CN/API/types/classes/Module.md
+++ b/doc/zh_CN/API/types/classes/Module.md
@@ -1,3 +1,5 @@
 # Module
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Module.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Module.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 ## 方法

--- a/doc/zh_CN/API/types/classes/Nat.md
+++ b/doc/zh_CN/API/types/classes/Nat.md
@@ -1,5 +1,7 @@
 # Nat
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Nat.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Nat.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 表示自然数的类型。 用于数组索引和范围类型
 
 ## 定义

--- a/doc/zh_CN/API/types/classes/Neg.md
+++ b/doc/zh_CN/API/types/classes/Neg.md
@@ -1,5 +1,7 @@
 # Neg
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Neg.md%26commit_hash%3D290c43b09f7c3036112a164bed5fd07a1f6a5cda)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Neg.md&commit_hash=290c43b09f7c3036112a164bed5fd07a1f6a5cda)
+
 表示负整数的类型。 Pos和Neg和{0} == Int
 它还具有一些值得注意的属性，例如不被零除和 Neg * Neg == Pos
 

--- a/doc/zh_CN/API/types/classes/Never.md
+++ b/doc/zh_CN/API/types/classes/Never.md
@@ -1,5 +1,7 @@
 # Never
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Never.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Never.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 它是所有类型的子类型。 它是一个`Class`，因为它拥有所有的方法，当然还有 `.new`。但是，它没有实例，并且Erg会在即将创建的那一刻停止。
 还有一种叫做`Panic`的类型没有实例，但是`Never`用于正常终止或故意无限循环，`Panic`用于异常终止。
 

--- a/doc/zh_CN/API/types/classes/NonZero.md
+++ b/doc/zh_CN/API/types/classes/NonZero.md
@@ -1,5 +1,7 @@
 # NonZero N
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/NonZero.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/NonZero.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 表示非零数的类。 保证除零的安全性
 
 ```mermaid

--- a/doc/zh_CN/API/types/classes/Object.md
+++ b/doc/zh_CN/API/types/classes/Object.md
@@ -1,5 +1,7 @@
 # Object
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Object.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Object.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 它是所有类型的超类型
 
 ## 方法

--- a/doc/zh_CN/API/types/classes/Operator.md
+++ b/doc/zh_CN/API/types/classes/Operator.md
@@ -1,5 +1,7 @@
 # Operator [...T], O
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Operator.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Operator.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 是运算符的类型
 
 ## 定义

--- a/doc/zh_CN/API/types/classes/Option.md
+++ b/doc/zh_CN/API/types/classes/Option.md
@@ -1,5 +1,7 @@
 # Option T = T or NoneType
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Option.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Option.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 表示“可能失败”的类型。
 
 ## 方法

--- a/doc/zh_CN/API/types/classes/Pos.md
+++ b/doc/zh_CN/API/types/classes/Pos.md
@@ -1,5 +1,7 @@
 # Pos
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Pos.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Pos.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 Pos是一种表示正数(大于或等于1的整数)的类型。
 由于不包括0，因此具有消除被零除的可能性等优点。
 

--- a/doc/zh_CN/API/types/classes/Ratio.md
+++ b/doc/zh_CN/API/types/classes/Ratio.md
@@ -1,5 +1,7 @@
 # Ratio
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Ratio.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Ratio.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 表示有理数的类型。 它主要用于当您要使用分数时。
 实际上，Erg中的/运算符返回 Ratio。1/3等不被评估为 0.33333... 并且被处理为1/3。 此外，0.1 相当于 1/10。 所以`0.1 + 0.2 == 0.3`。 这听起来很明显，但在 Python中它是False。
 但是，Ratio类型的效率往往比Float类型略低。 在执行速度很重要且不需要精确数值的地方应该使用浮点类型。 然而，正如Rob Pike所说，过早优化是万恶之源。 在丢弃Ratio类型并使用Float类型之前，请进行真实的性能测试。 业余爱好者无条件偏爱较轻的模具。

--- a/doc/zh_CN/API/types/classes/Record.md
+++ b/doc/zh_CN/API/types/classes/Record.md
@@ -1,5 +1,7 @@
 # Record
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Record.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Record.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 记录所属的类。例如，`{i = 1}` 是`Structural {i = Int}` 类型的元素，并且是`{i = Int}` 类的实例
 请注意，其他类的实例是记录类型的元素，而不是记录类的实例
 

--- a/doc/zh_CN/API/types/classes/Result.md
+++ b/doc/zh_CN/API/types/classes/Result.md
@@ -1,5 +1,7 @@
 # Result T, E
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Result.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Result.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 ```python
 Result T, E <: Error = Either T, E
 ```

--- a/doc/zh_CN/API/types/classes/Str!.md
+++ b/doc/zh_CN/API/types/classes/Str!.md
@@ -1,3 +1,5 @@
 # StrWithLen! N: Nat! = Inherit StrWithLen N
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Str!.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Str!.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 表示可变长度字符串的类型

--- a/doc/zh_CN/API/types/classes/Str.md
+++ b/doc/zh_CN/API/types/classes/Str.md
@@ -1,5 +1,7 @@
 # Str
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Str.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Str.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 (不变长度)表示字符串的类型。 简单的 `Str` 类型是删除了字符数的 `StrWithLen N` 类型(`Str = StrWithLen _`)
 
 ## 方法

--- a/doc/zh_CN/API/types/classes/StrWithLen.md
+++ b/doc/zh_CN/API/types/classes/StrWithLen.md
@@ -1,0 +1,2 @@
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/StrWithLen.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/StrWithLen.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+

--- a/doc/zh_CN/API/types/classes/Subroutine.md
+++ b/doc/zh_CN/API/types/classes/Subroutine.md
@@ -1,5 +1,7 @@
 # Subroutine
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Subroutine.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Subroutine.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 Func和Proc的基本类型。
 
 ## 方法

--- a/doc/zh_CN/API/types/classes/Tensor.md
+++ b/doc/zh_CN/API/types/classes/Tensor.md
@@ -1,5 +1,7 @@
 # Tensor Shape: [Nat; N]
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Tensor.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Tensor.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
   用于有效操作多维数组的类。 它还定义了诸如多维数组上的乘法之类的操作
   Matrix、Vector 等都继承自该类型
 

--- a/doc/zh_CN/API/types/classes/TransCell(T).md
+++ b/doc/zh_CN/API/types/classes/TransCell(T).md
@@ -1,5 +1,7 @@
 # TransCell! T: Type!
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/TransCell(T).md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/TransCell(T).md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 它是一个单元格，其内容可以针对每个模具进行更改。 由于它是T类型的子类型，因此它也表现为T类型
 当它在初始化时输入T时很有用，并且在某个点之后总是输入U
 

--- a/doc/zh_CN/API/types/classes/Tuple.md
+++ b/doc/zh_CN/API/types/classes/Tuple.md
@@ -1,5 +1,7 @@
 # Tuple T: ...Type
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Tuple.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Tuple.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 包含多种类型对象的集合
 
 ## 方法

--- a/doc/zh_CN/API/types/classes/Type.md
+++ b/doc/zh_CN/API/types/classes/Type.md
@@ -1,0 +1,2 @@
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Type.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Type.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+

--- a/doc/zh_CN/API/types/classes/Vector.md
+++ b/doc/zh_CN/API/types/classes/Vector.md
@@ -1,3 +1,5 @@
 # Vector T: Num, N: Nat
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/classes/Vector.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/classes/Vector.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 表示向量的类型。与同名的Rust和C++类型不同，这种类型只处理数字。

--- a/doc/zh_CN/API/types/patches/BinOp.md
+++ b/doc/zh_CN/API/types/patches/BinOp.md
@@ -1,5 +1,7 @@
 # BinOp L, R, O
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/patches/BinOp.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/patches/BinOp.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 二元运算符的类型
 
 ## 修补程序

--- a/doc/zh_CN/API/types/patches/UnaryOp.md
+++ b/doc/zh_CN/API/types/patches/UnaryOp.md
@@ -1,5 +1,7 @@
 # UnaryOp T, O
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/patches/UnaryOp.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/patches/UnaryOp.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 一元运算符的类型
 
 ## 定义

--- a/doc/zh_CN/API/types/traits/Add(R,O).md
+++ b/doc/zh_CN/API/types/traits/Add(R,O).md
@@ -1,5 +1,7 @@
 # Add R
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/traits/Add(R,O).md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/traits/Add(R,O).md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 ```python
 Add R = Trait {
     .AddO = Type

--- a/doc/zh_CN/API/types/traits/Div(R,O).md
+++ b/doc/zh_CN/API/types/traits/Div(R,O).md
@@ -1,5 +1,7 @@
 # Div R, O
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/traits/Div(R,O).md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/traits/Div(R,O).md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 如果除以零没有错误，请使用“SafeDiv”
 
 ```python

--- a/doc/zh_CN/API/types/traits/Eq.md
+++ b/doc/zh_CN/API/types/traits/Eq.md
@@ -1,0 +1,2 @@
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/traits/Eq.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/traits/Eq.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+

--- a/doc/zh_CN/API/types/traits/Into.md
+++ b/doc/zh_CN/API/types/traits/Into.md
@@ -1,5 +1,7 @@
 # Into T
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/traits/Into.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/traits/Into.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 一种类型，表明它可以被类型转换为类型T。
 即使Self和T之间没有继承关系，也是在关系可以相互转换的时候定义的。
 与继承不同，没有隐式转换。您必须始终调用 `.into` 方法。

--- a/doc/zh_CN/API/types/traits/Iterable.md
+++ b/doc/zh_CN/API/types/traits/Iterable.md
@@ -1,0 +1,2 @@
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/traits/Iterable.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/traits/Iterable.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+

--- a/doc/zh_CN/API/types/traits/Num.md
+++ b/doc/zh_CN/API/types/traits/Num.md
@@ -1,5 +1,7 @@
 # Num
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/traits/Num.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/traits/Num.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 ## 定义初始化
 
 ```python

--- a/doc/zh_CN/API/types/traits/Ord.md
+++ b/doc/zh_CN/API/types/traits/Ord.md
@@ -1,0 +1,2 @@
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/traits/Ord.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/traits/Ord.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+

--- a/doc/zh_CN/API/types/traits/SafeDiv(R,O).md
+++ b/doc/zh_CN/API/types/traits/SafeDiv(R,O).md
@@ -1,5 +1,7 @@
 # SafeDiv R, O
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/traits/SafeDiv(R,O).md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/traits/SafeDiv(R,O).md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 ```python
 SafeDiv R, O = Subsume Div, {
     @Override

--- a/doc/zh_CN/API/types/traits/Sample.md
+++ b/doc/zh_CN/API/types/traits/Sample.md
@@ -1,5 +1,7 @@
 # Sample
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/traits/Sample.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/traits/Sample.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 具有“随机”选择实例的`sample`和`sample!`方法的特征。`sample`方法总是返回相同的实例，而`sample!`方法返回一个随机实例，该实例随调用而变化
 
 请注意，这是一个假设您想要一个适当的实例进行测试等的特征，并且它不一定是随机的。 如果您想要随机抽样，请使用“随机”模块。

--- a/doc/zh_CN/API/types/traits/Seq.md
+++ b/doc/zh_CN/API/types/traits/Seq.md
@@ -1,0 +1,2 @@
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/traits/Seq.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/traits/Seq.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+

--- a/doc/zh_CN/API/types/traits/Show.md
+++ b/doc/zh_CN/API/types/traits/Show.md
@@ -1,0 +1,2 @@
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/traits/Show.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/traits/Show.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+

--- a/doc/zh_CN/API/types/traits/Unpack.md
+++ b/doc/zh_CN/API/types/traits/Unpack.md
@@ -1,5 +1,7 @@
 # Unpack
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/API/types/traits/Unpack.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/API/types/traits/Unpack.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 标记性状。实现时，元素可以像记录一样通过模式匹配来分解
 
 ```python

--- a/doc/zh_CN/compiler/TODO_hint.md
+++ b/doc/zh_CN/compiler/TODO_hint.md
@@ -1,4 +1,6 @@
 # 提示(未实现)
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/compiler/TODO_hint.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/compiler/TODO_hint.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 * `x 未定义`(x 已被`Del` 删除)=> `提示：在第 X 行删除`
 *补丁方法重复：“提示：指定补丁(如`T.foo(1)`)或使用`Del`删除任何`.foo`”

--- a/doc/zh_CN/compiler/TODO_recov_suggest.md
+++ b/doc/zh_CN/compiler/TODO_recov_suggest.md
@@ -1,5 +1,7 @@
 # 错误恢复建议(尚未实现)
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/compiler/TODO_recov_suggest.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/compiler/TODO_recov_suggest.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 *  `1 or 2`, `1 and 2` => `{1, 2}`?
 * `U = Inherit T` => 非类类型不能被继承，或者`U = Class T`？
 * `Int and Str` => 不允许多重继承，或者`Int or Str`？

--- a/doc/zh_CN/compiler/TODO_warn.md
+++ b/doc/zh_CN/compiler/TODO_warn.md
@@ -1,5 +1,7 @@
 # 警告(尚未实现)
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/compiler/TODO_warn.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/compiler/TODO_warn.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 * `t = {(record type)}` => `T = {(record type)}`?(只有定义为常量的类型才能用于类型说明)
 * `{I: Int | ...}!` => `{I: Int! | ...}`
 * for/while 块中的`return x`(`x != ()`) => `f::return`(外部块)？

--- a/doc/zh_CN/compiler/abandoned.md
+++ b/doc/zh_CN/compiler/abandoned.md
@@ -1,5 +1,7 @@
 # 废弃/拒绝的语言规范
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/compiler/abandoned.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/compiler/abandoned.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 ## 重载(临时多态性)
 
 被放弃了，因为它可以用参数+子类型多态来代替，并且与Python的语义不兼容。 有关详细信息，请参阅 [overload](../syntax/type/overloading.md) 文章。

--- a/doc/zh_CN/compiler/architecture.md
+++ b/doc/zh_CN/compiler/architecture.md
@@ -1,5 +1,7 @@
 # `ergc` 的架构
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/compiler/architecture.md%26commit_hash%3Da711efa99b325ba1012f6897e7b0e2bdb947d8a1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/compiler/architecture.md&commit_hash=a711efa99b325ba1012f6897e7b0e2bdb947d8a1)
+
 ## 1. 扫描 Erg 脚本 (.er) 并生成 `TokenStream` (parser/lex.rs)
 
 * parser/lexer/Lexer 生成`TokenStream`(这是一个Token的迭代器，TokenStream可以通过lexer.collect()生成)

--- a/doc/zh_CN/compiler/errors.md
+++ b/doc/zh_CN/compiler/errors.md
@@ -1,5 +1,7 @@
 # Erg Compiler Errors
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/compiler/errors.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/compiler/errors.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 ## AssignError
 
 尝试重写不可变变量时发生

--- a/doc/zh_CN/compiler/hir.md
+++ b/doc/zh_CN/compiler/hir.md
@@ -1,5 +1,7 @@
 # 高级中间表示(HIR, High-level Intermediate Representation)
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/compiler/hir.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/compiler/hir.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 HIR 是 Erg 编译器从 AST 生成的结构
 此结构包含源代码中每个表达式的完整类型信息，并且在语法上已脱糖
 AST与源代码一一对应(纯文本)，但是HIR去掉了不必要的代码信息，添加了省略的类型信息，所以HIR可以转换为源代码很难恢复

--- a/doc/zh_CN/compiler/index.md
+++ b/doc/zh_CN/compiler/index.md
@@ -1,0 +1,2 @@
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/compiler/index.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/compiler/index.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+

--- a/doc/zh_CN/compiler/inference.md
+++ b/doc/zh_CN/compiler/inference.md
@@ -1,5 +1,7 @@
 # 类型推断算法
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/compiler/inference.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/compiler/inference.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 > __Warning__：此部分正在编辑中，可能包含一些错误
 
 显示了下面使用的符号

--- a/doc/zh_CN/compiler/overview.md
+++ b/doc/zh_CN/compiler/overview.md
@@ -1,5 +1,7 @@
 # `erg` 概览
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/compiler/overview.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/compiler/overview.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 我们将介绍每一层的功能以及特别重要的功能和方法。
 
 ## 1. 词法分析

--- a/doc/zh_CN/compiler/parsing.md
+++ b/doc/zh_CN/compiler/parsing.md
@@ -1,5 +1,7 @@
 # 解析 Erg 语言
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/compiler/parsing.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/compiler/parsing.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 ## 空格的处理
 
 Erg语法的一个特点是它对空间敏感。

--- a/doc/zh_CN/compiler/refinement_subtyping.md
+++ b/doc/zh_CN/compiler/refinement_subtyping.md
@@ -1,5 +1,7 @@
 # 筛子类型
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/compiler/refinement_subtyping.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/compiler/refinement_subtyping.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 ```python
 {I: Int | I >= 0}
 {S: StrWithLen N | N >= 1}

--- a/doc/zh_CN/compiler/trait_method_resolving.md
+++ b/doc/zh_CN/compiler/trait_method_resolving.md
@@ -1,5 +1,7 @@
 # 解决补丁方法
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/compiler/trait_method_resolving.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/compiler/trait_method_resolving.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 `Nat` 是零个或多个`Int`，`Int` 的子类型。
 `Nat` 在 Python 类层次结构中不存在。 我想知道 Erg 是如何解决这个补丁方法的？
 

--- a/doc/zh_CN/compiler/transpile.md
+++ b/doc/zh_CN/compiler/transpile.md
@@ -1,5 +1,7 @@
 # Erg 代码如何转译成 Python 代码？
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/compiler/transpile.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/compiler/transpile.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 准确地说，Erg 代码被转译为 Python 字节码。
 但是，由于 Python 字节码几乎可以重构为 Python 代码，因此这里以等效的 Python 代码为例。
 顺便说一句，这里展示的示例是低优化级别。

--- a/doc/zh_CN/compiler/type_var_normalization.md
+++ b/doc/zh_CN/compiler/type_var_normalization.md
@@ -1,5 +1,7 @@
 # 归一化
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/compiler/type_var_normalization.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/compiler/type_var_normalization.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 * Erg 的类型参数规范化基于 SymPy 的简化函数。
 
 例如，当您定义 `concat: |T, M, N|([T; M], [T; N] -> [T; M+N])` 时，您可以匹配类型变量和参数而无需实例化它们.必须作出判断。

--- a/doc/zh_CN/dev_guide/branches.md
+++ b/doc/zh_CN/dev_guide/branches.md
@@ -1,5 +1,7 @@
 # 分支机构命名和运营策略
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/dev_guide/branches.md%26commit_hash%3Da711efa99b325ba1012f6897e7b0e2bdb947d8a1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/dev_guide/branches.md&commit_hash=a711efa99b325ba1012f6897e7b0e2bdb947d8a1)
+
 ## main
 
 * 主要开发分支

--- a/doc/zh_CN/dev_guide/build_features.md
+++ b/doc/zh_CN/dev_guide/build_features.md
@@ -1,5 +1,7 @@
 # `erg` 构建功能
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/dev_guide/build_features.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/dev_guide/build_features.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 ## 调试
 
 进入调试模式。结果，Erg 内部的行为顺序显示在日志中。

--- a/doc/zh_CN/dev_guide/directories.md
+++ b/doc/zh_CN/dev_guide/directories.md
@@ -1,5 +1,7 @@
 # Erg存储表结构
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/dev_guide/directories.md%26commit_hash%3Da711efa99b325ba1012f6897e7b0e2bdb947d8a1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/dev_guide/directories.md&commit_hash=a711efa99b325ba1012f6897e7b0e2bdb947d8a1)
+
 ```console
   └─┬ assets：图片等
     ├─ CODE_OF_CONDUCT：行为准则

--- a/doc/zh_CN/dev_guide/doc_guideline.md
+++ b/doc/zh_CN/dev_guide/doc_guideline.md
@@ -1,5 +1,7 @@
 # 格式
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/dev_guide/doc_guideline.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/dev_guide/doc_guideline.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 任何不符合以下规则的文件都将得到更正。
 
 * 以某种语气写代码注释或内部文档。

--- a/doc/zh_CN/dev_guide/env.md
+++ b/doc/zh_CN/dev_guide/env.md
@@ -1,5 +1,7 @@
 # 开发环境
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/dev_guide/env.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/dev_guide/env.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 ## 你需要安装什么
 
 * Rust(与 rustup 一起安装)

--- a/doc/zh_CN/dev_guide/faq_syntax.md
+++ b/doc/zh_CN/dev_guide/faq_syntax.md
@@ -1,5 +1,7 @@
 # Erg design's "Why" and Answers
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/dev_guide/faq_syntax.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/dev_guide/faq_syntax.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 ## 当我们有所有权系统时，为什么要与 GC 共存？
 
 因为 Erg 推出所有权系统的动机并不是为了 Rust 那样的“不依赖 GC 的内存管理”。最初，由于 Erg 是一种语言，目前使用 Python VM，因此最终仍使用 GC。Erg 引入产权系统的目标是“可变状态的局部化”。在 Erg 中，可变对象具有所有权概念。这是根据共享可变状态容易成为 bug 的温床，甚至是类型安全性的侵犯(详见)来判断的。

--- a/doc/zh_CN/dev_guide/i18n_messages.md
+++ b/doc/zh_CN/dev_guide/i18n_messages.md
@@ -1,5 +1,7 @@
 # 多语言错误信息
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/dev_guide/i18n_messages.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/dev_guide/i18n_messages.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 Erg 正在推动消息(开始、选项、文档、提示、警告、错误消息等)的多语言化。如果你不熟悉 Rust 或 Erg，也可以参与此项目。请务必配合。
 
 以下是多语种方法的说明。

--- a/doc/zh_CN/dev_guide/index.md
+++ b/doc/zh_CN/dev_guide/index.md
@@ -1,0 +1,2 @@
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/dev_guide/index.md%26commit_hash%3D7d43acdf0e2b71528b038b9a8e70be6c93831f96)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/dev_guide/index.md&commit_hash=7d43acdf0e2b71528b038b9a8e70be6c93831f96)
+

--- a/doc/zh_CN/dev_guide/rust_code_guideline.md
+++ b/doc/zh_CN/dev_guide/rust_code_guideline.md
@@ -1,5 +1,7 @@
 # Rust 代码指南
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/dev_guide/rust_code_guideline.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/dev_guide/rust_code_guideline.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 ## 本地规则
 
 * 使用 `log!` 进行调试输出(使用 `println!` 等进行输出处理，这也是发布所必需的)。

--- a/doc/zh_CN/dev_guide/terms.md
+++ b/doc/zh_CN/dev_guide/terms.md
@@ -1,5 +1,7 @@
 # 词汇表
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/dev_guide/terms.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/dev_guide/terms.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 ## 象征
 
 ### &excl;

--- a/doc/zh_CN/dev_guide/unify_terms.md
+++ b/doc/zh_CN/dev_guide/unify_terms.md
@@ -1,5 +1,7 @@
 # 术语统一
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/dev_guide/unify_terms.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/dev_guide/unify_terms.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 ## 可访问性，可见性
 
 使用可见性。

--- a/doc/zh_CN/faq_general.md
+++ b/doc/zh_CN/faq_general.md
@@ -1,8 +1,10 @@
 # Erg常见问题
 
-此常见问题解答适用于一般 Erg 初学者。
-对于个别(常见)技术问题，请参阅 [此处](./faq_technical.md) 了解个别(常见)技术问题，以及
-[这里](./dev_guide/faq_syntax.md) 了解更多信息。
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/faq_general.md%26commit_hash%3Deccd113c1512076c367fb87ea73406f91ff83ba7)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/faq_general.md&commit_hash=eccd113c1512076c367fb87ea73406f91ff83ba7)
+
+This FAQ is intended for the general Erg beginner.
+For individual (common) technical issues, please refer to [here](./faq_technical.md) for individual (common) technical issues, and
+[Here](./dev_guide/faq_syntax.md) for more information.
 
 ## Erg 是 Python 兼容语言是什么意思？
 

--- a/doc/zh_CN/faq_technical.md
+++ b/doc/zh_CN/faq_technical.md
@@ -1,5 +1,7 @@
 # 技术常见问题
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/faq_technical.md%26commit_hash%3Dc120700585fdb1d655255c8e2817bb13cc8d369e)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/faq_technical.md&commit_hash=c120700585fdb1d655255c8e2817bb13cc8d369e)
+
 本节回答有关使用 Erg 语言的技术问题。换句话说，它包含以 What 或 Which 开头的问题，以及可以用 Yes/No 回答的问题。
 
 有关如何确定语法的更多信息，请参阅 [此处](./dev_guide/faq_syntax.md) 了解基础语法决策，以及 [此处](./dev_guide/../faq_general.md)。

--- a/doc/zh_CN/improved_points.md
+++ b/doc/zh_CN/improved_points.md
@@ -1,5 +1,7 @@
 # Python 的改进
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/improved_points.md%26commit_hash%3Deccd113c1512076c367fb87ea73406f91ff83ba7)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/improved_points.md&commit_hash=eccd113c1512076c367fb87ea73406f91ff83ba7)
+
 ## 执行静态分析(静态类型检查、变量和属性检查)
 
 静态类型检查的好处现在怎么强调都不为过，但是检查变量和属性的存在也是相当重要的一部分。

--- a/doc/zh_CN/index.md
+++ b/doc/zh_CN/index.md
@@ -1,5 +1,7 @@
 # 索引
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/index.md%26commit_hash%3Deccd113c1512076c367fb87ea73406f91ff83ba7)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/index.md&commit_hash=eccd113c1512076c367fb87ea73406f91ff83ba7)
+
 ## [API/](./API/index.md)
 
     本节介绍 Erg 的内置或标准库提供的子程序、类型、常量等的规范。

--- a/doc/zh_CN/migration_from_py.md
+++ b/doc/zh_CN/migration_from_py.md
@@ -1,5 +1,7 @@
 # 从 Python 迁移到 Erg 的提示
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/migration_from_py.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/migration_from_py.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 ## 我想将字符串转换为 int 等。
 
 使用 `Str` 类的 `parse` 方法。 它返回一个 `Result` 类型。

--- a/doc/zh_CN/python/bytecode_instructions.md
+++ b/doc/zh_CN/python/bytecode_instructions.md
@@ -1,5 +1,7 @@
 # Python 字节码指令
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/python/bytecode_instructions.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/python/bytecode_instructions.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 Python 字节码变量操作命令通过 名称索引(名称索引)访问。 这是为了在 Python 中实现动态变量访问(可以使用 eval 等作为字符串访问)。
 一条指令为 2 个字节，指令和参数以 little endian 形式存储。
 不带参数的指令也使用 2 个字节(参数部分为 0)。

--- a/doc/zh_CN/python/bytecode_specification.md
+++ b/doc/zh_CN/python/bytecode_specification.md
@@ -1,5 +1,7 @@
 # Python bytecode specification
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/python/bytecode_specification.md%26commit_hash%3D9f6a4a43fcf7e4f58cabe6e5a7546820fd9f5ff4)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/python/bytecode_specification.md&commit_hash=9f6a4a43fcf7e4f58cabe6e5a7546820fd9f5ff4)
+
 ## Format
 
 * 0~3 byte(u32): magic number (see common/bytecode.rs for details)

--- a/doc/zh_CN/python/class_system.md
+++ b/doc/zh_CN/python/class_system.md
@@ -1,5 +1,7 @@
 # Python 类系统(与 Erg 比较)
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/python/class_system.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/python/class_system.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 ## 方法
 
 方法可以被前向引用，但这不是一种特殊的技术。

--- a/doc/zh_CN/python/index.md
+++ b/doc/zh_CN/python/index.md
@@ -1,0 +1,2 @@
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/python/index.md%26commit_hash%3D9f6a4a43fcf7e4f58cabe6e5a7546820fd9f5ff4)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/python/index.md&commit_hash=9f6a4a43fcf7e4f58cabe6e5a7546820fd9f5ff4)
+

--- a/doc/zh_CN/syntax/00_basic.md
+++ b/doc/zh_CN/syntax/00_basic.md
@@ -1,5 +1,7 @@
 # 基本
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/00_basic.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/00_basic.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 > __Warning__：本文档不完整。 它未经校对(样式、正确链接、误译等)。 此外，Erg 的语法可能在版本 0.* 期间发生破坏性更改，并且文档可能没有相应更新。 请事先了解这一点。
 > 如果您在本文档中发现任何错误，请报告至 [此处的表单](https://forms.gle/HtLYRfYzWCAaeTGb6) 或 [GitHub repo](https://github.com/mtshiba/TheErgBook/issues/new )。 我们将不胜感激您的建议。
 

--- a/doc/zh_CN/syntax/01_literal.md
+++ b/doc/zh_CN/syntax/01_literal.md
@@ -1,5 +1,7 @@
 # 字面量
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/01_literal.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/01_literal.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 ## 基本字面量
 
 ### 整数字面量

--- a/doc/zh_CN/syntax/02_name.md
+++ b/doc/zh_CN/syntax/02_name.md
@@ -1,5 +1,7 @@
 # 多变的
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/02_name.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/02_name.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 变量是一种代数； Erg 中的代数 - 如果没有混淆，有时简称为变量 - 指的是命名对象并使它们可从代码的其他地方引用的功能。
 
 变量定义如下。

--- a/doc/zh_CN/syntax/03_declaration.md
+++ b/doc/zh_CN/syntax/03_declaration.md
@@ -1,5 +1,7 @@
 # 宣言(Declaration)
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/03_declaration.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/03_declaration.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 声明是用于指定要使用的变量类型的语法。
 可以在代码中的任何地方进行声明，但单独的声明并不引用变量。 它们必须被初始化。
 分配后，可以检查声明以确保类型与分配它的对象兼容。

--- a/doc/zh_CN/syntax/04_function.md
+++ b/doc/zh_CN/syntax/04_function.md
@@ -1,5 +1,7 @@
 ＃ 功能
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/04_function.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/04_function.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 函数是一个块，它接受一个“参数”，对其进行处理，并将其作为“返回值”返回。 定义如下。
 
 ```python

--- a/doc/zh_CN/syntax/05_builtin_funcs.md
+++ b/doc/zh_CN/syntax/05_builtin_funcs.md
@@ -1,5 +1,7 @@
 # 内置函数
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/05_builtin_funcs.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/05_builtin_funcs.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 ＃＃ 如果
 
 `if` 是一个根据条件改变处理的函数。

--- a/doc/zh_CN/syntax/06_operator.md
+++ b/doc/zh_CN/syntax/06_operator.md
@@ -1,5 +1,7 @@
 # 运算符
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/06_operator.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/06_operator.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 运算符是表示操作的符号。 操作数是运算符(左)右侧的东西。
 
 运算符是一种函数，因此它们本身就是可以绑定到变量的一流对象。 绑定时，需要用```括起来。

--- a/doc/zh_CN/syntax/07_side_effect.md
+++ b/doc/zh_CN/syntax/07_side_effect.md
@@ -1,5 +1,7 @@
 # 副作用和程序
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/07_side_effect.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/07_side_effect.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 我们一直忽略了解释“！”的含义，但现在它的含义终于要揭晓了。 这个 `!` 表示这个对象是一个带有“副作用”的“过程”。 过程是具有副作用的函数。
 
 ```python

--- a/doc/zh_CN/syntax/08_procedure.md
+++ b/doc/zh_CN/syntax/08_procedure.md
@@ -1,5 +1,7 @@
 # 程序
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/08_procedure.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/08_procedure.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 处理可变对象时需要过程，但将可变对象作为参数并不一定使其成为过程。
 这是一个函数接受一个可变对象(不是过程)。
 

--- a/doc/zh_CN/syntax/09_builtin_procs.md
+++ b/doc/zh_CN/syntax/09_builtin_procs.md
@@ -1,5 +1,7 @@
 # 内置程序
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/09_builtin_procs.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/09_builtin_procs.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 ## id！
 
 返回对象的唯一标识号。

--- a/doc/zh_CN/syntax/10_array.md
+++ b/doc/zh_CN/syntax/10_array.md
@@ -1,5 +1,7 @@
 # Array
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/10_array.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/10_array.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 数组是最基本的__collection(聚合)__。
 集合是一个可以在其中包含多个对象的对象。
 

--- a/doc/zh_CN/syntax/11_tuple.md
+++ b/doc/zh_CN/syntax/11_tuple.md
@@ -1,5 +1,7 @@
 # 元组
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/11_tuple.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/11_tuple.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 元组类似于数组，但可以保存不同类型的对象。
 这样的集合称为不等集合。 相比之下，同构集合包括数组、集合等。
 

--- a/doc/zh_CN/syntax/12_dict.md
+++ b/doc/zh_CN/syntax/12_dict.md
@@ -1,5 +1,7 @@
 # 字典
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/12_dict.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/12_dict.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 Dict 是键/值对的集合。
 
 ```python

--- a/doc/zh_CN/syntax/13_record.md
+++ b/doc/zh_CN/syntax/13_record.md
@@ -1,5 +1,7 @@
 # 记录(Record)
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/13_record.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/13_record.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 记录是一个集合，它结合了通过键访问的 Dict 和在编译时检查其访问的元组的属性。
 如果您了解 JavaScript，请将其视为一种(更增强的)对象字面量表示法。
 

--- a/doc/zh_CN/syntax/14_set.md
+++ b/doc/zh_CN/syntax/14_set.md
@@ -1,5 +1,7 @@
 # Set
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/14_set.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/14_set.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 一个Set代表一个集合，它在结构上是一个重复的无序数组。
 
 ```python

--- a/doc/zh_CN/syntax/15_type.md
+++ b/doc/zh_CN/syntax/15_type.md
@@ -1,5 +1,7 @@
 # 类型
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/15_type.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/15_type.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 类型是 Erg 中一个非常重要的特性，所以我们有一个 [dedicated section](./type/01_type_system.md)。 请看那里。
 
 <p align='center'>

--- a/doc/zh_CN/syntax/16_iterator.md
+++ b/doc/zh_CN/syntax/16_iterator.md
@@ -1,5 +1,7 @@
 # 迭代器
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/16_iterator.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/16_iterator.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 迭代器是用于检索容器元素的对象。
 
 ```python

--- a/doc/zh_CN/syntax/17_mutability.md
+++ b/doc/zh_CN/syntax/17_mutability.md
@@ -1,5 +1,7 @@
 # 可变性
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/17_mutability.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/17_mutability.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 正如我们已经看到的，所有 Erg 变量都是不可变的。 但是，Erg 对象具有可变性的概念。
 以下面的代码为例。
 

--- a/doc/zh_CN/syntax/18_ownership.md
+++ b/doc/zh_CN/syntax/18_ownership.md
@@ -1,5 +1,7 @@
 #所有权制度
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/18_ownership.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/18_ownership.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 由于 Erg 是一种使用 Python 作为宿主语言的语言，因此内存管理的方法取决于 Python 的实现。
 但语义上 Erg 的内存管理与 Python 的不同。 一个显着的区别在于所有权制度和禁止循环引用。
 

--- a/doc/zh_CN/syntax/19_visibility.md
+++ b/doc/zh_CN/syntax/19_visibility.md
@@ -1,5 +1,7 @@
 # 可见性
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/19_visibility.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/19_visibility.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 Erg 变量具有 __visibility__ 的概念。
 到目前为止，我们看到的所有变量都称为 __private variables__。 这是一个外部不可见的变量。
 例如，`foo` 模块中定义的私有变量不能被另一个模块引用。

--- a/doc/zh_CN/syntax/20_naming_rule.md
+++ b/doc/zh_CN/syntax/20_naming_rule.md
@@ -1,5 +1,7 @@
 # 命名约定
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/20_naming_rule.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/20_naming_rule.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 如果要将变量用作常量表达式，请确保它以大写字母开头。 两个或多个字母可能是小写的。
 
 ```python

--- a/doc/zh_CN/syntax/21_lambda.md
+++ b/doc/zh_CN/syntax/21_lambda.md
@@ -1,5 +1,7 @@
 # 匿名函数
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/21_lambda.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/21_lambda.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 匿名函数是一种无需命名即可动态创建函数对象的语法。
 
 ```python

--- a/doc/zh_CN/syntax/22_subroutine.md
+++ b/doc/zh_CN/syntax/22_subroutine.md
@@ -1,5 +1,7 @@
 # 子程序签名
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/22_subroutine.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/22_subroutine.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 ## 函数
 
 ```python

--- a/doc/zh_CN/syntax/23_closure.md
+++ b/doc/zh_CN/syntax/23_closure.md
@@ -1,5 +1,7 @@
 # 关闭
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/23_closure.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/23_closure.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 Erg 子例程有一个称为“闭包”的功能，可以捕获外部变量。
 
 ```python

--- a/doc/zh_CN/syntax/24_module.md
+++ b/doc/zh_CN/syntax/24_module.md
@@ -1,5 +1,7 @@
 # module
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/24_module.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/24_module.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 Erg allows you to think of the file itself as a single record. This is called a module.
 
 ```python: foo.er

--- a/doc/zh_CN/syntax/25_object_system.md
+++ b/doc/zh_CN/syntax/25_object_system.md
@@ -1,5 +1,7 @@
 ＃ 目的
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/25_object_system.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/25_object_system.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 可以分配给变量的所有数据。 `Object` 类的属性如下。
 
 * `.__repr__`：返回对象的(非丰富)字符串表示

--- a/doc/zh_CN/syntax/26_pattern_matching.md
+++ b/doc/zh_CN/syntax/26_pattern_matching.md
@@ -1,5 +1,7 @@
 # 模式匹配，可反驳
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/26_pattern_matching.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/26_pattern_matching.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 ## Erg 中可用的模式
 
 ### 变量模式

--- a/doc/zh_CN/syntax/27_comprehension.md
+++ b/doc/zh_CN/syntax/27_comprehension.md
@@ -1,5 +1,7 @@
 # Comprehension
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/27_comprehension.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/27_comprehension.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 Array 和 `[expr | (name <- iterable)+ (predicate)*]`,
 set 和 `{expr | (name <- iterable)+ (predicate)*}`,
 你可以创建一个字典 `{key: value | (name <- iterable)+ (predicate)*}`.

--- a/doc/zh_CN/syntax/28_spread_syntax.md
+++ b/doc/zh_CN/syntax/28_spread_syntax.md
@@ -1,5 +1,7 @@
 # 传播赋值
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/28_spread_syntax.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/28_spread_syntax.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 在分解赋值中，将 `...` 放在变量前面会将所有剩余元素展开到该变量中。 这称为扩展赋值。
 
 ```python

--- a/doc/zh_CN/syntax/29_decorator.md
+++ b/doc/zh_CN/syntax/29_decorator.md
@@ -1,5 +1,7 @@
 # 装饰器(修饰符)
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/29_decorator.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/29_decorator.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 装饰器用于向类型或函数添加或演示特定状态或行为。
 装饰器的语法如下。
 

--- a/doc/zh_CN/syntax/30_error_handling.md
+++ b/doc/zh_CN/syntax/30_error_handling.md
@@ -1,5 +1,7 @@
 # 错误处理系统
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/30_error_handling.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/30_error_handling.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 主要使用Result类型。
 在 Erg 中，如果您丢弃 Error 类型的对象(顶层不支持)，则会发生错误。
 

--- a/doc/zh_CN/syntax/31_pipeline.md
+++ b/doc/zh_CN/syntax/31_pipeline.md
@@ -1,5 +1,7 @@
 # 管道运算符
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/31_pipeline.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/31_pipeline.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 管道运算符的使用方式如下：
 
 ```python

--- a/doc/zh_CN/syntax/32_integration_with_Python.md
+++ b/doc/zh_CN/syntax/32_integration_with_Python.md
@@ -1,5 +1,7 @@
 # 与 Python 集成
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/32_integration_with_Python.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/32_integration_with_Python.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 ## 导出到 Python
 
 编译 Erg 脚本时，会生成一个 .pyc 文件，可以简单地将其作为 Python 模块导入。

--- a/doc/zh_CN/syntax/33_package_system.md
+++ b/doc/zh_CN/syntax/33_package_system.md
@@ -1,5 +1,7 @@
 # 打包系统
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/33_package_system.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/33_package_system.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 Erg包大致可以分为app包，即应用程序，以及lib包，即库。
 应用包的入口点是`src/app.er`。 `app.er` 中定义的`main` 函数被执行。
 lib 包的入口点是`src/lib.er`。导入包相当于导入 `lib.er`。

--- a/doc/zh_CN/syntax/34_generator.md
+++ b/doc/zh_CN/syntax/34_generator.md
@@ -1,5 +1,7 @@
 # 生成器
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/34_generator.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/34_generator.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 生成器是在块中使用 `yield!` 过程的特殊过程。
 
 ```python

--- a/doc/zh_CN/syntax/SUMMARY.md
+++ b/doc/zh_CN/syntax/SUMMARY.md
@@ -1,5 +1,7 @@
 ＃ 概括
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/SUMMARY.md%26commit_hash%3D2ce482b1c8407332b3b74f4c3e5596f373f9a657)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/SUMMARY.md&commit_hash=2ce482b1c8407332b3b74f4c3e5596f373f9a657)
+
 - [基础](./00_basic.md)
 - [文字](./01_literal.md)
 - [名称](02_name.md)

--- a/doc/zh_CN/syntax/container_ownership.md
+++ b/doc/zh_CN/syntax/container_ownership.md
@@ -1,5 +1,7 @@
 # 下标(索引访问)
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/container_ownership.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/container_ownership.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 `[]` 不同于普通的方法。
 
 ```python

--- a/doc/zh_CN/syntax/indexes.md
+++ b/doc/zh_CN/syntax/indexes.md
@@ -1,5 +1,7 @@
 # 指数
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/indexes.md%26commit_hash%3D438bcb89ea692f219b30f3a3ba107888b23eae98)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/indexes.md&commit_hash=438bcb89ea692f219b30f3a3ba107888b23eae98)
+
 有关不在此索引中的 API，请参阅 [此处](../API/index.md)。
 有关术语，请参见 [此处](../dev_guide/terms.md)。
 

--- a/doc/zh_CN/syntax/quick_tour.md
+++ b/doc/zh_CN/syntax/quick_tour.md
@@ -1,5 +1,7 @@
 # 快速浏览
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/quick_tour.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/quick_tour.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 `syntax` 下面的文档是为了让编程初学者也能理解而编写的。
 对于已经掌握 Python、Rust、Haskell 等语言的人来说，可能有点啰嗦。
 

--- a/doc/zh_CN/syntax/type/01_type_system.md
+++ b/doc/zh_CN/syntax/type/01_type_system.md
@@ -1,5 +1,7 @@
 # Erg 的类型系统
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/01_type_system.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/01_type_system.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 下面简单介绍一下 Erg 的类型系统。 详细信息在其他部分进行说明。
 
 ## 如何定义

--- a/doc/zh_CN/syntax/type/02_basic.md
+++ b/doc/zh_CN/syntax/type/02_basic.md
@@ -1,5 +1,7 @@
 # 类型的基本语法
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/02_basic.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/02_basic.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 ## 类型规范
 
 在 Erg 中，可以在 `:` 之后指定变量的类型，如下所示。这可以与作业同时完成。

--- a/doc/zh_CN/syntax/type/03_trait.md
+++ b/doc/zh_CN/syntax/type/03_trait.md
@@ -1,5 +1,7 @@
 # 特质
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/03_trait.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/03_trait.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 Trait 是一种名义类型，它将类型属性要求添加到记录类型。
 它类似于 Python 中的抽象基类 (ABC)，但区别在于能够执行代数运算。
 

--- a/doc/zh_CN/syntax/type/04_class.md
+++ b/doc/zh_CN/syntax/type/04_class.md
@@ -1,5 +1,7 @@
 # Class
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/04_class.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/04_class.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 Erg 中的类大致是一种可以创建自己的元素(实例)的类型。
 这是一个简单类的示例。
 

--- a/doc/zh_CN/syntax/type/05_inheritance.md
+++ b/doc/zh_CN/syntax/type/05_inheritance.md
@@ -1,5 +1,7 @@
 # 继承
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/05_inheritance.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/05_inheritance.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 继承允许您定义一个新类，为现有类添加功能或专业化。
 继承类似于包含在特征中。 继承的类成为原始类的子类型。
 

--- a/doc/zh_CN/syntax/type/06_nst_vs_sst.md
+++ b/doc/zh_CN/syntax/type/06_nst_vs_sst.md
@@ -1,5 +1,7 @@
 # 名义子类型与结构子类型
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/06_nst_vs_sst.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/06_nst_vs_sst.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 ```python
 Months = 0..12
 

--- a/doc/zh_CN/syntax/type/07_patch.md
+++ b/doc/zh_CN/syntax/type/07_patch.md
@@ -1,5 +1,7 @@
 # 修补
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/07_patch.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/07_patch.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 Erg 不允许修改现有类型和类。
 这意味着，不可能在类中定义额外的方法，也不能执行特化(一种语言特性，单态化多态声明的类型并定义专用方法，如在 C++ 中)。
 但是，在许多情况下，您可能希望向现有类型或类添加功能，并且有一个称为“修补”的功能允许您执行此操作。

--- a/doc/zh_CN/syntax/type/08_value.md
+++ b/doc/zh_CN/syntax/type/08_value.md
@@ -1,5 +1,7 @@
 # 值类型
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/08_value.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/08_value.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 值类型是可以在编译时评估的 Erg 内置类型，具体来说：
 
 ```python

--- a/doc/zh_CN/syntax/type/09_attributive.md
+++ b/doc/zh_CN/syntax/type/09_attributive.md
@@ -1,5 +1,7 @@
 # 属性类型
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/09_attributive.md%26commit_hash%3Deccd113c1512076c367fb87ea73406f91ff83ba7)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/09_attributive.md&commit_hash=eccd113c1512076c367fb87ea73406f91ff83ba7)
+
 属性类型是包含 Record 和 Dataclass、Patch、Module 等的类型。
 属于属性类型的类型不是值类型。
 

--- a/doc/zh_CN/syntax/type/10_interval.md
+++ b/doc/zh_CN/syntax/type/10_interval.md
@@ -1,5 +1,7 @@
 # 间隔类型
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/10_interval.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/10_interval.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 `Range` 对象最基本的用途是作为迭代器。
 
 ```python

--- a/doc/zh_CN/syntax/type/11_enum.md
+++ b/doc/zh_CN/syntax/type/11_enum.md
@@ -1,5 +1,7 @@
 # 枚举类型
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/11_enum.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/11_enum.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 Set 生成的枚举类型。
 枚举类型可以与类型规范一起使用，但可以通过将它们分类为类或定义修复程序来定义进一步的方法。
 

--- a/doc/zh_CN/syntax/type/12_refinement.md
+++ b/doc/zh_CN/syntax/type/12_refinement.md
@@ -1,5 +1,7 @@
 # 细化类型
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/12_refinement.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/12_refinement.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 细化类型是受谓词表达式约束的类型。 枚举类型和区间类型是细化类型的语法糖。
 
 细化类型的标准形式是`{Elem: Type | (预)*}`。 这意味着该类型是其元素为满足 `Pred` 的 `Elem` 的类型。

--- a/doc/zh_CN/syntax/type/13_algebraic.md
+++ b/doc/zh_CN/syntax/type/13_algebraic.md
@@ -1,5 +1,7 @@
 # 代数类型
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/13_algebraic.md%26commit_hash%3Dc120700585fdb1d655255c8e2817bb13cc8d369e)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/13_algebraic.md&commit_hash=c120700585fdb1d655255c8e2817bb13cc8d369e)
+
 代数类型是通过将类型视为代数来操作类型而生成的类型。
 它们处理的操作包括Union、Intersection、Diff、Complement等。
 普通类只能进行Union，其他操作会导致类型错误。

--- a/doc/zh_CN/syntax/type/14_dependent.md
+++ b/doc/zh_CN/syntax/type/14_dependent.md
@@ -1,5 +1,7 @@
 # 依赖类型
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/14_dependent.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/14_dependent.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 依赖类型是一个特性，可以说是 Erg 的最大特性。
 依赖类型是将值作为参数的类型。 普通的多态类型只能将类型作为参数，但依赖类型放宽了这个限制。
 

--- a/doc/zh_CN/syntax/type/15_quantified.md
+++ b/doc/zh_CN/syntax/type/15_quantified.md
@@ -1,5 +1,7 @@
 # 类型变量，量化类型
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/15_quantified.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/15_quantified.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 类型变量是用于例如指定子程序参数类型的变量，它的类型是任意的(不是单态的)。
 首先，作为引入类型变量的动机，考虑 `id` 函数，它按原样返回输入。
 

--- a/doc/zh_CN/syntax/type/16_subtyping.md
+++ b/doc/zh_CN/syntax/type/16_subtyping.md
@@ -1,5 +1,7 @@
 # 子类型
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/16_subtyping.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/16_subtyping.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 在 Erg 中，可以使用比较运算符 `<`、`>` 确定类包含。
 
 ```python

--- a/doc/zh_CN/syntax/type/17_type_casting.md
+++ b/doc/zh_CN/syntax/type/17_type_casting.md
@@ -1,5 +1,7 @@
 ＃ 投掷
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/17_type_casting.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/17_type_casting.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 ## 向上转型
 
 因为 Python 是一种使用鸭子类型的语言，所以没有强制转换的概念。没有必要向上转型，本质上也没有向下转型。

--- a/doc/zh_CN/syntax/type/18_mut.md
+++ b/doc/zh_CN/syntax/type/18_mut.md
@@ -1,5 +1,7 @@
 # 可变类型
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/18_mut.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/18_mut.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 > __Warning__：本节中的信息是旧的并且包含一些错误。
 
 默认情况下，Erg 中的所有类型都是不可变的，即它们的内部状态无法更新。

--- a/doc/zh_CN/syntax/type/19_bound.md
+++ b/doc/zh_CN/syntax/type/19_bound.md
@@ -1,5 +1,7 @@
 # 类型绑定
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/19_bound.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/19_bound.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 类型边界为类型规范添加条件。 实现这一点的函数是守卫(守卫子句)。
 此功能可用于函数签名、匿名函数签名以及筛选类型。
 守卫写在返回类型之后。

--- a/doc/zh_CN/syntax/type/advanced.md
+++ b/doc/zh_CN/syntax/type/advanced.md
@@ -1,1 +1,2 @@
-下面，我们将讨论更高级的类型系统。 初学者不必阅读所有部分。
+下面，我们将讨论更高级的类型系统。 初学者不必阅读所有部分。[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/advanced.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/advanced.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+

--- a/doc/zh_CN/syntax/type/advanced/GADTs.md
+++ b/doc/zh_CN/syntax/type/advanced/GADTs.md
@@ -1,5 +1,7 @@
 # 广义代数数据类型 (GADT)
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/advanced/GADTs.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/advanced/GADTs.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 Erg 可以通过对 Or 类型进行分类来创建广义代数数据类型 (GADT)。
 
 ```python

--- a/doc/zh_CN/syntax/type/advanced/_rank2type.md
+++ b/doc/zh_CN/syntax/type/advanced/_rank2type.md
@@ -1,5 +1,7 @@
 # rank-2 多态性
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/advanced/_rank2type.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/advanced/_rank2type.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 > __Warning__：本文档已过时，一般包含错误。
 
 Erg 允许您定义接受各种类型的函数，例如 `id|T|(x: T): T = x`，即多相关。

--- a/doc/zh_CN/syntax/type/advanced/default_param.md
+++ b/doc/zh_CN/syntax/type/advanced/default_param.md
@@ -1,5 +1,7 @@
 # 带默认参数的函数类型
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/advanced/default_param.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/advanced/default_param.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 首先，让我们看一个使用默认参数的示例。
 
 ```python

--- a/doc/zh_CN/syntax/type/advanced/erasure.md
+++ b/doc/zh_CN/syntax/type/advanced/erasure.md
@@ -1,5 +1,7 @@
 # 类型擦除
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/advanced/erasure.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/advanced/erasure.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 类型擦除是将类型参数设置为 `_` 并故意丢弃其信息的过程。类型擦除是许多多态语言的特性，但在 Erg 的语法上下文中，将其称为类型参数擦除更为准确。
 
 类型擦除的最常见示例是 `[T, _]`。数组在编译时并不总是知道它们的长度。例如，引用命令行参数的 `sys.argv` 的类型为 `[Str, _]`。由于 Erg 的编译器无法知道命令行参数的长度，因此必须放弃有关其长度的信息。

--- a/doc/zh_CN/syntax/type/advanced/existential.md
+++ b/doc/zh_CN/syntax/type/advanced/existential.md
@@ -1,5 +1,7 @@
 # 存在类型
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/advanced/existential.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/advanced/existential.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 如果存在对应于∀的for-all类型，那么很自然地假设存在对应于∃的存在类型。
 存在类型并不难。 你已经知道存在类型，只是没有意识到它本身。
 

--- a/doc/zh_CN/syntax/type/advanced/keyword_param.md
+++ b/doc/zh_CN/syntax/type/advanced/keyword_param.md
@@ -1,5 +1,7 @@
 # 带有关键字参数的函数类型
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/advanced/keyword_param.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/advanced/keyword_param.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 ```python
 h(f) = f(y: 1, x: 2)
 h: |T: type|((y: Int, x: Int) -> T) -> T

--- a/doc/zh_CN/syntax/type/advanced/kind.md
+++ b/doc/zh_CN/syntax/type/advanced/kind.md
@@ -1,5 +1,7 @@
 # Kind
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/advanced/kind.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/advanced/kind.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 一切都在 Erg 中输入。类型本身也不例外。 __kind__ 表示“类型的类型”。例如，`Int` 属于 `Type`，就像 `1` 属于 `Int`。 `Type` 是最简单的一种，__atomic kind__。在类型论符号中，`Type` 对应于 `*`。
 
 在Kind的概念中，实际上重要的是一种或多种Kind(多项式Kind)。单项类型，例如`Option`，属于它。一元Kind表示为 `Type -> Type` [<sup id="f1">1</sup>](#1)。诸如 `Array` 或 `Option` 之类的 __container__ 特别是一种以类型作为参数的多项式类型。

--- a/doc/zh_CN/syntax/type/advanced/marker_trait.md
+++ b/doc/zh_CN/syntax/type/advanced/marker_trait.md
@@ -1,5 +1,7 @@
 # 标记特征
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/advanced/marker_trait.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/advanced/marker_trait.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 标记特征是没有必需属性的特征。 也就是说，您可以在不实现任何方法的情况下实现 Impl。
 没有 required 属性似乎没有意义，但由于注册了它属于 trait 的信息，因此可以使用 patch 方法或由编译器进行特殊处理。
 

--- a/doc/zh_CN/syntax/type/advanced/mut_struct.md
+++ b/doc/zh_CN/syntax/type/advanced/mut_struct.md
@@ -1,5 +1,7 @@
 # 可变结构类型
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/advanced/mut_struct.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/advanced/mut_struct.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 `T!` 类型被描述为可以被任何 `T` 类型对象替换的盒子类型。
 
 ```python

--- a/doc/zh_CN/syntax/type/advanced/newtype.md
+++ b/doc/zh_CN/syntax/type/advanced/newtype.md
@@ -1,5 +1,7 @@
 # 新类型模式
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/advanced/newtype.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/advanced/newtype.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 这是 Rust 中常用的 newtype 模式的 Erg 版本。
 
 Erg 允许定义类型别名如下，但它们只引用相同的类型。

--- a/doc/zh_CN/syntax/type/advanced/overloading.md
+++ b/doc/zh_CN/syntax/type/advanced/overloading.md
@@ -1,5 +1,7 @@
 # 重载
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/advanced/overloading.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/advanced/overloading.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 Erg 不支持 __ad hoc 多态性__。 也就是说，函数和种类(重载)的多重定义是不可能的。 但是，您可以通过使用特征和补丁的组合来重现重载行为。
 您可以使用特征而不是特征类，但随后将涵盖所有实现 `.add1` 的类型。
 

--- a/doc/zh_CN/syntax/type/advanced/phantom.md
+++ b/doc/zh_CN/syntax/type/advanced/phantom.md
@@ -1,5 +1,7 @@
 # 幻影(phantom)类
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/advanced/phantom.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/advanced/phantom.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 幻像类型是标记特征，其存在仅用于向编译器提供注释。
 作为幻像类型的一种用法，让我们看一下列表的结构。
 

--- a/doc/zh_CN/syntax/type/advanced/projection.md
+++ b/doc/zh_CN/syntax/type/advanced/projection.md
@@ -1,5 +1,7 @@
 # 投影类型
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/advanced/projection.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/advanced/projection.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 投影类型表示如下代码中的“Self.AddO”等类型。
 
 ```python

--- a/doc/zh_CN/syntax/type/advanced/quantified_dependent.md
+++ b/doc/zh_CN/syntax/type/advanced/quantified_dependent.md
@@ -1,5 +1,7 @@
 # 量化依赖类型
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/advanced/quantified_dependent.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/advanced/quantified_dependent.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 Erg 有量化和依赖类型。 那么很自然地，就可以创建一个将两者结合起来的类型。 那是量化的依赖类型。
 
 ```python

--- a/doc/zh_CN/syntax/type/advanced/shared.md
+++ b/doc/zh_CN/syntax/type/advanced/shared.md
@@ -1,5 +1,7 @@
 # 共享参考
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/advanced/shared.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/advanced/shared.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 共享引用是必须小心处理的语言特性之一。
 例如，在 TypeScript 中，以下代码将通过类型检查。
 

--- a/doc/zh_CN/syntax/type/advanced/special.md
+++ b/doc/zh_CN/syntax/type/advanced/special.md
@@ -1,5 +1,7 @@
 # 特殊类型(Self、Super)
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/advanced/special.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/advanced/special.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 `Self` 代表它自己的类型。 您可以将其用作别名，但请注意派生类型的含义会发生变化(指的是自己的类型)。
 
 ```python

--- a/doc/zh_CN/syntax/type/advanced/typeof.md
+++ b/doc/zh_CN/syntax/type/advanced/typeof.md
@@ -1,5 +1,7 @@
 # Typeof, classof
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/advanced/typeof.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/advanced/typeof.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 `Typeof` 是一个可以窥探 Erg 类型推断系统的函数，它的行为很复杂
 
 ```python

--- a/doc/zh_CN/syntax/type/advanced/variance.md
+++ b/doc/zh_CN/syntax/type/advanced/variance.md
@@ -1,5 +1,7 @@
 # 变化
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/advanced/variance.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/advanced/variance.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 Erg 可以对多态类型进行子类型化，但有一些注意事项。
 
 首先，考虑普通多态类型的包含关系。一般来说，有一个容器`K`和它分配的类型`A，B`，当`A < B`时，`K A < K B`。

--- a/doc/zh_CN/syntax/type/advanced/widening.md
+++ b/doc/zh_CN/syntax/type/advanced/widening.md
@@ -1,5 +1,7 @@
 # 类型加宽
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/syntax/type/advanced/widening.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/syntax/type/advanced/widening.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 例如，定义多相关系数如下。
 
 ```python

--- a/doc/zh_CN/tips.md
+++ b/doc/zh_CN/tips.md
@@ -1,5 +1,7 @@
 # 提示
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/tips.md%26commit_hash%3D51de3c9d5a9074241f55c043b9951b384836b258)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/tips.md&commit_hash=51de3c9d5a9074241f55c043b9951b384836b258)
+
 ## 想要更改显示错误的语言
 
 请为您的语言下载 Erg。

--- a/doc/zh_CN/tools/build.md
+++ b/doc/zh_CN/tools/build.md
@@ -1,5 +1,7 @@
 # 构建子命令
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/tools/build.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/tools/build.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 build 子命令构建包。
 默认构建中执行的步骤如下：
 

--- a/doc/zh_CN/tools/env.md
+++ b/doc/zh_CN/tools/env.md
@@ -1,5 +1,7 @@
 # 环境子命令
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/tools/env.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/tools/env.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 env 子命令指定 erg 执行环境。
 使用 `erg env new [env name]` 创建一个新的执行环境。 将打开一个交互式工具，当您指定 erg 版本时，将安装该版本的 erg(如果已存在，将使用它)，您将能够将其用作新环境。
 您可以使用 `erg env switch [env name]` 切换环境。

--- a/doc/zh_CN/tools/fmt.md
+++ b/doc/zh_CN/tools/fmt.md
@@ -1,5 +1,7 @@
 # fmt
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/tools/fmt.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/tools/fmt.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 可以使用 fmt 子命令来完成代码格式化。
 常用的标志有：
 

--- a/doc/zh_CN/tools/index.md
+++ b/doc/zh_CN/tools/index.md
@@ -1,0 +1,2 @@
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/tools/index.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/tools/index.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+

--- a/doc/zh_CN/tools/install.md
+++ b/doc/zh_CN/tools/install.md
@@ -1,5 +1,7 @@
 # 安装子命令
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/tools/install.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/tools/install.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 您可以使用 install 安装在注册表站点上注册的软件包。
 基本用法与cargo等包管理器相同。
 

--- a/doc/zh_CN/tools/pack.md
+++ b/doc/zh_CN/tools/pack.md
@@ -1,5 +1,7 @@
 # 包管理器
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/tools/pack.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/tools/pack.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 Erg 标配有一个包管理器，您可以使用 `pack` 子命令调用它。
 以下是典型的选项。
 

--- a/doc/zh_CN/tools/repl.md
+++ b/doc/zh_CN/tools/repl.md
@@ -1,5 +1,7 @@
 # REPL
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/tools/repl.md%26commit_hash%3Dd15cbbf7b33df0f78a575cff9679d84c36ea3ab1)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/tools/repl.md&commit_hash=d15cbbf7b33df0f78a575cff9679d84c36ea3ab1)
+
 运行不带参数的 `erg` 命令会调用 REPL。 它也可以用 `repl` 子命令调用。
 此外，您可以指定以下标志：
 

--- a/doc/zh_CN/tools/test.md
+++ b/doc/zh_CN/tools/test.md
@@ -1,5 +1,7 @@
 # 测试子命令
 
+[![badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com%2Fdefault%2Fsource_up_to_date%3Fowner%3Derg-lang%26repos%3Derg%26ref%3Dmain%26path%3Ddoc/EN/tools/test.md%26commit_hash%3D06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)](https://gezf7g7pd5.execute-api.ap-northeast-1.amazonaws.com/default/source_up_to_date?owner=erg-lang&repos=erg&ref=main&path=doc/EN/tools/test.md&commit_hash=06f8edc9e2c0cee34f6396fd7c64ec834ffb5352)
+
 erg 命令有一个名为 test 的子命令，它支持测试的实现和执行。
 
 ## 测试装饰器 (@Test)


### PR DESCRIPTION
Note: Some of the badges are working well, but most are not, because they refer to the main branch of erg-lang.
After merging them into erg-lang/main, we should check to see if they are working.

- Updated hash values in README.md
- Added translation badges to all. md files in JA directory
- Added translation badges to all .md files in zh_CN directory
