### PR TITLE
Improvements to REPL testing and the addition of dummy_run to accompany it

### DIFF
--- a/crates/erg_common/config.rs
+++ b/crates/erg_common/config.rs
@@ -92,7 +92,7 @@ impl DummyStdin {
         }
         let line = self.lines[self.current_line].clone();
         self.current_line += 1;
-        Some(line)
+        println!("{}", line);
     }
 
     pub fn reread_lines(&self, ln_begin: usize, ln_end: usize) -> Vec<String> {

--- a/crates/erg_common/config.rs
+++ b/crates/erg_common/config.rs
@@ -86,13 +86,16 @@ impl DummyStdin {
         }
     }
 
-    pub fn read_line(&mut self) -> Option<String> {
+    pub fn read_line(&mut self) -> String {
         if self.current_line >= self.lines.len() {
-            return None;
+            let exit = ":exit".to_string();
+            println!("{exit}");
+            return exit;
         }
         let line = self.lines[self.current_line].clone();
         self.current_line += 1;
         println!("{}", line);
+        line
     }
 
     pub fn reread_lines(&self, ln_begin: usize, ln_end: usize) -> Vec<String> {
@@ -212,7 +215,7 @@ impl Input {
             }
             Self::Pipe(s) | Self::Str(s) => s.clone(),
             Self::REPL => GLOBAL_STDIN.read(),
-            Self::DummyREPL(dummy) => dummy.read_line().unwrap_or_default(),
+            Self::DummyREPL(dummy) => dummy.read_line(),
             Self::Dummy => panic!("cannot read from a dummy file"),
         }
     }

--- a/crates/erg_common/error.rs
+++ b/crates/erg_common/error.rs
@@ -350,11 +350,7 @@ fn format_context<E: ErrorDisplay + ?Sized>(
     hint: Option<&String>,
 ) -> String {
     let mark = mark.to_string();
-    let codes = if e.input().is_repl() {
-        vec![e.input().reread()]
-    } else {
-        e.input().reread_lines(ln_begin, ln_end)
-    };
+    let codes = e.input().reread_lines(ln_begin, ln_end);
     let mut context = StyledStrings::default();
     let final_step = ln_end - ln_begin;
     let max_digit = ln_end.to_string().len();
@@ -525,11 +521,7 @@ impl SubMessage {
                 let input = e.input();
                 let (vbreak, vbar) = chars.gutters();
                 let mut cxt = StyledStrings::default();
-                let codes = if input.is_repl() {
-                    vec![input.reread()]
-                } else {
-                    input.reread_lines(ln_begin as usize, ln_end as usize)
-                };
+                let codes = input.reread_lines(ln_begin as usize, ln_end as usize);
                 let mark = mark.to_string();
                 for (i, lineno) in (ln_begin..=ln_end).enumerate() {
                     cxt.push_str_with_color(&format!("{lineno} {vbar} "), gutter_color);
@@ -557,13 +549,9 @@ impl SubMessage {
             Location::Line(lineno) => {
                 let input = e.input();
                 let (_, vbar) = chars.gutters();
-                let code = if input.is_repl() {
-                    input.reread()
-                } else {
-                    input
-                        .reread_lines(lineno as usize, lineno as usize)
-                        .remove(0)
-                };
+                let code = input
+                    .reread_lines(lineno as usize, lineno as usize)
+                    .remove(0);
                 let mut cxt = StyledStrings::default();
                 cxt.push_str_with_color(&format!(" {lineno} {} ", vbar), gutter_color);
                 cxt.push_str(&code);

--- a/crates/erg_common/traits.rs
+++ b/crates/erg_common/traits.rs
@@ -502,13 +502,13 @@ pub fn from_str(bk: &str) -> BlockKind {
 }
 
 pub struct VirtualMachine {
-    codes: String,
-    now_block: Vec<BlockKind>,
-    now: BlockKind,
-    length: usize,
+    pub codes: String,
+    pub now_block: Vec<BlockKind>,
+    pub now: BlockKind,
+    pub length: usize,
 }
 impl VirtualMachine {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             codes: String::new(),
             now_block: vec![BlockKind::Main],
@@ -517,30 +517,30 @@ impl VirtualMachine {
         }
     }
 
-    fn push_block_kind(&mut self, bk: BlockKind) {
+    pub fn push_block_kind(&mut self, bk: BlockKind) {
         self.now = bk;
         self.now_block.push(bk);
         self.length += 1;
     }
 
-    fn remove_block_kind(&mut self) {
+    pub fn remove_block_kind(&mut self) {
         self.now_block.pop().unwrap();
         self.now = *self.now_block.last().unwrap();
         self.length -= 1;
     }
 
-    fn push_code(&mut self, src: &str) {
+    pub fn push_code(&mut self, src: &str) {
         self.codes.push_str(src)
     }
 
-    fn clear(&mut self) {
+    pub fn clear(&mut self) {
         self.codes = String::new();
         self.now_block = vec![BlockKind::Main];
         self.now = BlockKind::Main;
         self.length = 1;
     }
 
-    fn indent(&self) -> String {
+    pub fn indent(&self) -> String {
         if self.now == BlockKind::MultiLineStr {
             String::new()
         } else if self.now_block.contains(&BlockKind::AtMark) {

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -27,6 +27,19 @@ pub(crate) fn expect_repl_success(lines: Vec<String>) -> Result<(), ()> {
     }
 }
 
+pub(crate) fn expect_repl_unsuccess(lines: Vec<String>, errs_len: usize) -> Result<(), ()> {
+    match exec_repl(lines) {
+        Ok(_) => Err(()),
+        Err(errs) => {
+            if errs.len() == errs_len {
+                return Ok(());
+            }
+            println!("err: error length is not {errs_len} but {}", errs.len());
+            Err(())
+        }
+    }
+}
+
 pub(crate) fn expect_success(file_path: &'static str) -> Result<(), ()> {
     match exec_file(file_path) {
         Ok(0) => Ok(()),
@@ -121,8 +134,7 @@ pub fn _exec_repl(lines: Vec<String>) -> Result<i32, CompileErrors> {
         quiet_repl: true,
         ..Default::default()
     };
-    <DummyVM as Runnable>::run(set_cfg(cfg));
-    Ok(0)
+    DummyVM::dummy_run(set_cfg(cfg))
 }
 
 pub(crate) fn exec_file(file_path: &'static str) -> Result<i32, CompileErrors> {

--- a/tests/repl.rs
+++ b/tests/repl.rs
@@ -1,19 +1,93 @@
 mod common;
 use common::expect_repl_success;
+use common::expect_repl_unsuccess;
 
 #[test]
 fn exec_repl_helloworld() -> Result<(), ()> {
-    expect_repl_success(vec!["print! \"hello, world\"".into(), "exit()".into()])
+    expect_repl_success(
+        ["print! \"hello, world\"", "exit()"]
+            .into_iter()
+            .map(|x| x.to_string())
+            .collect(),
+    )
 }
 
 #[test]
 fn exec_repl_def_func() -> Result<(), ()> {
-    expect_repl_success(vec![
-        "f i =".into(),
-        "i + 1".into(),
-        "".into(),
-        "x = f 2".into(),
-        "assert x == 3".into(),
-        "exit()".into(),
-    ])
+    expect_repl_success(
+        [
+            "f i =",
+            "i + 1",
+            "",
+            "x = f 2",
+            "assert x == 3",
+            "x == 3",
+            ":exit",
+        ]
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect(),
+    )
+}
+
+#[test]
+fn exec_repl_def_loop() -> Result<(), ()> {
+    expect_repl_success(
+        ["for! 0..1, i =>", "print! i", "", ":exit"]
+            .into_iter()
+            .map(|line| line.to_string())
+            .collect(),
+    )
+}
+
+#[test]
+fn exec_repl_auto_indent_dedent_check() -> Result<(), ()> {
+    expect_repl_success(
+        [
+            "for! 0..0, i =>",
+            "for! 0..0, j =>",
+            "for! 0..0, k =>",
+            "for! 0..0, l =>",
+            "print! \"hi\"",
+            "# l indent",
+            "", // dedent l
+            "# k indent",
+            "", // dedent k
+            "# j indent",
+            "", // dedent j
+            "# i indent and `for!` loop finished",
+            "",
+            "# main",
+            ":exit",
+        ]
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect(),
+    )
+}
+
+#[test]
+fn exec_repl_check_exit() -> Result<(), ()> {
+    expect_repl_success(["", ""].into_iter().map(|x| x.to_string()).collect())
+}
+
+#[test]
+fn exec_repl_invalid_indent() -> Result<(), ()> {
+    expect_repl_unsuccess(
+        [
+            "a =",
+            "    1",
+            "2",
+            "",
+            "x =>",
+            "1",
+            "    print! \"hi\"",
+            "",
+            ":quit",
+        ]
+        .into_iter()
+        .map(|x| x.to_string())
+        .collect(),
+        3,
+    )
 }


### PR DESCRIPTION
The original test always returned Ok(())

Negative test could not be added because of this

In addition, `DummyVM::run()` is constrained by the trait.rs and cannot have a return value

That's why, I made a dummy_run() method for REPL test

I've made some changes to accommodate this